### PR TITLE
Config options for more efficient endianness handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ QCBOR encodes and decodes [RFC 7049](https://tools.ietf.org/html/rfc7049) CBOR.
 
 ## Characteristics
 
-**Implemented in C with minimal dependency** – Only dependencies are
-  C99, <stdint.h>, <stddef.h>, <stdbool.h> and <string.h> making it
-  highly portable. There are no #ifdefs to be configured at all.
+**Implemented in C with minimal dependency** – The only dependencies
+  are C99, <stdint.h>, <stddef.h>, <stdbool.h> and <string.h> making it
+  highly portable. No #ifdefs or compiler options need to be set for it
+  to run correctly.
 
 **Focused on C / native data representation** – Simpler code because
   there is no support for encoding/decoding to/from JSON, pretty
@@ -104,6 +105,15 @@ support UNIX style command line and make, you should be able to make a
 simple project and add the test files to it.  Then just call
 RunTests() to invoke them all.
 
+While this code will run fine without configuration, there are several
+C pre processor macros that can be defined in order to:
+
+* use a more efficient implementation
+  * to reduce code size
+  * to improve performance (a little)
+* remove features to reduce code size
+
+See the comment sections on "Configuration" in inc/UsefulBuf.h.
 
 ## Changes from CAF Version
 * Float support is restored

--- a/inc/UsefulBuf.h
+++ b/inc/UsefulBuf.h
@@ -129,6 +129,13 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  instructions. Since they are inline, they size effect is not in the
  UsefulBuf object code, but in the calling code.
 
+ Summary:
+   USEFULBUF_CONFIG_BIG_ENDIAN -- Force configuration to big-endian.
+   USEFULBUF_CONFIG_LITTLE_ENDIAN -- Force to little-endian.
+   USEFULBUF_CONFIG_HTON -- Use hton(), htonl(), ntohl()... to
+     handle big and little-endian with system option.
+   USEFULBUF_CONFIG_BSWAP -- With USEFULBUF_CONFIG_LITTLE_ENDIAN,
+     use __builtin_bswapXX().
  */
 
 #if defined(USEFULBUF_CONFIG_BIG_ENDIAN) && defined(USEFULBUF_CONFIG_LITTLE_ENDIAN)

--- a/inc/UsefulBuf.h
+++ b/inc/UsefulBuf.h
@@ -61,6 +61,7 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
  =============================================================================*/
 
+
 #ifndef _UsefulBuf_h
 #define _UsefulBuf_h
 
@@ -128,7 +129,7 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  also affect the 16-, 32-bit, float and double versions of these
  instructions. Since they are inline, they size effect is not in the
  UsefulBuf object code, but in the calling code.
- 
+
  */
 
 #if defined(USEFULBUF_CONFIG_BIG_ENDIAN) && defined(USEFULBUF_CONFIG_LITTLE_ENDIAN)

--- a/inc/UsefulBuf.h
+++ b/inc/UsefulBuf.h
@@ -41,6 +41,7 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
  when         who             what, where, why
  --------     ----            --------------------------------------------------
+ 5/21/2019    llundblade      #define configs for efficient endianness handling.
  3/23/2019    llundblade      Big documentation & style update. No interface
                               change.
  3/6/2019     llundblade      Add UsefulBuf_IsValue()
@@ -64,9 +65,69 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define _UsefulBuf_h
 
 
+/*
+ Configuration Options
+
+ This code is designed so it will work correctly and completely by
+ default. No configuration is necessary to make it work. None of the
+ following #defines need to be enabled. The code works and is very
+ portable with them all turned off.
+
+ All configuration options (USEFULBUF_CONFIG_XXX)
+    1) Reduce code size
+    2) Improve efficiency
+    3) Both of the above
+
+ The efficiency improvements are not large, so the main reason really
+ is to reduce code size.
+ */
+
+
+/*
+ Endianness Configuration
+
+ By default, UsefulBuf does not need to know what the endianness of the
+ device is. All the code will run correctly on either big or little
+ endian CPUs.
+
+ Here's the recipie for configuring the endianness-related #defines.
+
+ The first option is to not define anything. This will work fine on
+ with all CPU's, OS's and compilers. The code will be a little larger
+ and slower.
+
+ If your CPU is big-endian then define USEFULBUF_CONFIG_BIG_ENDIAN. This
+ will give the most efficient code for big-endian CPUs. It will be smalll
+ and efficient because there will be no byte swapping.
+
+ Try defining USEFULBUF_CONFIG_HTON. This will work on most CPU's, OS's and
+ compilers, but not all. It will usually give small and efficient code
+ for both big- and little-endian CPU's because it will call the system
+ defined byte swapping library which is presumably implemented
+ efficiently. In some cases this will be a dedicated byte swap
+ instruction like Intel bswap.
+
+ If you know your CPU is little-endian, the best thing to do is
+ define both USEFULBUF_CONFIG_HTON and USEFULBUF_CONFIG_LITTLE_ENDIAN.
+ USEFULBUF_CONFIG_HTON will usually give the smallest and best code
+ for little-endian CPUs.
+
+ Last, run the tests. They should all pass.
+ */
+
+#if defined(USEFULBUF_CONFIG_BIG_ENDIAN) && defined(USEFULBUF_CONFIG_LITTLE_ENDIAN)
+#error "Cannot define both USEFULBUF_CONFIG_BIG_ENDIAN and USEFULBUF_CONFIG_LITTLE_ENDIAN"
+#endif
+
+
 #include <stdint.h> // for uint8_t, uint16_t....
 #include <string.h> // for strlen, memcpy, memmove, memset
 #include <stddef.h> // for size_t
+
+
+#ifdef USEFULBUF_CONFIG_HTON
+#include <arpa/inet.h> // for htons, htonl, htonll, ntohs...
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -1570,11 +1631,27 @@ static inline void UsefulOutBuf_InsertUint16(UsefulOutBuf *me,
                                              uint16_t uInteger16,
                                              size_t uPos)
 {
-   // Converts native integer format to network byte order (big endian)
-   uint8_t tmp[2];
-   tmp[0] = (uInteger16 & 0xff00) >> 8;
-   tmp[1] = (uInteger16 & 0xff);
-   UsefulOutBuf_InsertData(me, tmp, 2, uPos);
+   // See UsefulOutBuf_InsertUint64() for comments on this code
+
+   const void *pBytes;
+
+#if defined(USEFULBUF_CONFIG_BIG_ENDIAN)
+   pBytes = &uInteger16;
+
+#elif defined(USEFULBUF_CONFIG_HTON)
+   uint16_t uTmp = htons(uInteger16);
+   pBytes        = &uTmp;
+
+#else
+   uint8_t aTmp[2];
+
+   aTmp[0] = (uInteger16 & 0xff00) >> 8;
+   aTmp[1] = (uInteger16 & 0xff);
+
+   pBytes = aTmp;
+#endif
+
+   UsefulOutBuf_InsertData(me, pBytes, 2, uPos);
 }
 
 
@@ -1582,13 +1659,29 @@ static inline void UsefulOutBuf_InsertUint32(UsefulOutBuf *pMe,
                                              uint32_t uInteger32,
                                              size_t uPos)
 {
-   // Converts native integer format to network byte order (big endian)
-   uint8_t tmp[4];
-   tmp[0] = (uInteger32 & 0xff000000) >> 24;
-   tmp[1] = (uInteger32 & 0xff0000) >> 16;
-   tmp[2] = (uInteger32 & 0xff00) >> 8;
-   tmp[3] = (uInteger32 & 0xff);
-   UsefulOutBuf_InsertData(pMe, tmp, 4, uPos);
+   // See UsefulOutBuf_InsertUint64() for comments on this code
+
+   const void *pBytes;
+
+#if defined(USEFULBUF_CONFIG_BIG_ENDIAN)
+   pBytes = &uInteger32;
+
+#elif defined(USEFULBUF_CONFIG_HTON)
+   uint32_t uTmp = htonl(uInteger32);
+   pBytes = &uTmp;
+
+#else
+   uint8_t aTmp[4];
+
+   aTmp[0] = (uInteger32 & 0xff000000) >> 24;
+   aTmp[1] = (uInteger32 & 0xff0000) >> 16;
+   aTmp[2] = (uInteger32 & 0xff00) >> 8;
+   aTmp[3] = (uInteger32 & 0xff);
+
+   pBytes = aTmp;
+#endif
+
+   UsefulOutBuf_InsertData(pMe, pBytes, 4, uPos);
 }
 
 
@@ -1596,17 +1689,46 @@ static inline void UsefulOutBuf_InsertUint64(UsefulOutBuf *pMe,
                                              uint64_t uInteger64,
                                              size_t uPos)
 {
-   // Converts native integer format to network byte order (big endian)
-   uint8_t tmp[8];
-   tmp[0] = (uInteger64 & 0xff00000000000000) >> 56;
-   tmp[1] = (uInteger64 & 0xff000000000000) >> 48;
-   tmp[2] = (uInteger64 & 0xff0000000000) >> 40;
-   tmp[3] = (uInteger64 & 0xff00000000) >> 32;
-   tmp[4] = (uInteger64 & 0xff000000) >> 24;
-   tmp[5] = (uInteger64 & 0xff0000) >> 16;
-   tmp[6] = (uInteger64 & 0xff00) >> 8;
-   tmp[7] = (uInteger64 & 0xff);
-   UsefulOutBuf_InsertData(pMe, tmp, 8, uPos);
+   const void *pBytes;
+
+#if defined(USEFULBUF_CONFIG_BIG_ENDIAN)
+   // We have been told explicitly we are running on a big-endian
+   // machine. Network byte order is big endian, so just copy.  There
+   // is no issue with alignment here because uInter64 is always
+   // aligned (and it doesn't matter if pBytes is aligned).
+   pBytes = &uInteger64;
+
+#elif defined(USEFULBUF_CONFIG_HTON)
+   // Use system function to handle big- and little-endian. This works
+   // on both big- and little-endian machines, but hton() is not
+   // always available or in a standard place so it is not used by
+   // default. With some compilers and CPUs the code for this is very
+   // compact through use of a special swap instruction and on
+   // big-endian machines hton() will reduce to nothing.
+   uint64_t uTmp = htonll(uInteger64);
+
+   pBytes = &uTmp;
+
+#else
+   // Default which works on every CPU with no dependency on anything
+   // from the CPU, compiler, libraries or OS.  This always works, but
+   // it is usually a little larger and slower than hton().
+   uint8_t aTmp[8];
+
+   aTmp[0] = (uInteger64 & 0xff00000000000000) >> 56;
+   aTmp[1] = (uInteger64 & 0xff000000000000) >> 48;
+   aTmp[2] = (uInteger64 & 0xff0000000000) >> 40;
+   aTmp[3] = (uInteger64 & 0xff00000000) >> 32;
+   aTmp[4] = (uInteger64 & 0xff000000) >> 24;
+   aTmp[5] = (uInteger64 & 0xff0000) >> 16;
+   aTmp[6] = (uInteger64 & 0xff00) >> 8;
+   aTmp[7] = (uInteger64 & 0xff);
+
+   pBytes = aTmp;
+#endif
+
+   // Do the insert
+   UsefulOutBuf_InsertData(pMe, pBytes, sizeof(uint64_t), uPos);
 }
 
 
@@ -1791,7 +1913,23 @@ static inline uint16_t UsefulInputBuf_GetUint16(UsefulInputBuf *pMe)
       return 0;
    }
 
+   // See UsefulInputBuf_GetUint64() for comments on this code
+#if defined(USEFULBUF_CONFIG_BIG_ENDIAN) || defined(USEFULBUF_CONFIG_HTON)
+   uint16_t uTmp;
+   memcpy(&uTmp, pResult, sizeof(uint16_t));
+
+#if defined(USEFULBUF_CONFIG_BIG_ENDIAN)
+   return uTmp;
+
+#else
+   return ntohs(uTmp);
+
+#endif
+
+#else
    return  ((uint16_t)pResult[0] << 8) + (uint16_t)pResult[1];
+
+#endif
 }
 
 
@@ -1803,10 +1941,25 @@ static inline uint32_t UsefulInputBuf_GetUint32(UsefulInputBuf *pMe)
       return 0;
    }
 
+   // See UsefulInputBuf_GetUint64() for comments on this code
+#if defined(USEFULBUF_CONFIG_BIG_ENDIAN) || defined(USEFULBUF_CONFIG_HTON)
+   uint32_t uTmp;
+   memcpy(&uTmp, pResult, sizeof(uint32_t));
+
+#if defined(USEFULBUF_CONFIG_BIG_ENDIAN)
+   return uTmp;
+
+#else
+   return ntohl(uTmp);
+
+#endif
+
+#else
    return ((uint32_t)pResult[0]<<24) +
-   ((uint32_t)pResult[1]<<16) +
-   ((uint32_t)pResult[2]<<8) +
-   (uint32_t)pResult[3];
+          ((uint32_t)pResult[1]<<16) +
+          ((uint32_t)pResult[2]<<8)  +
+           (uint32_t)pResult[3];
+#endif
 }
 
 
@@ -1818,14 +1971,44 @@ static inline uint64_t UsefulInputBuf_GetUint64(UsefulInputBuf *pMe)
       return 0;
    }
 
+#if defined(USEFULBUF_CONFIG_BIG_ENDIAN) || defined(USEFULBUF_CONFIG_HTON)
+   // pResult will probably not be aligned.  This memcpy() moves the
+   // bytes into a temp variable safely for CPUs that can or can't do
+   // unaligned memory access. Many compilers will optimize the
+   // memcpy() into a simple move instruction.
+   uint64_t uTmp;
+   memcpy(&uTmp, pResult, sizeof(uint64_t));
+
+#if defined(USEFULBUF_CONFIG_BIG_ENDIAN)
+   // We have been told expliclity this is a big-endian CPU.  Since
+   // network byte order is big-endian, there is nothing to do.
+
+   return uTmp;
+#else
+   // We have been told to use ntoh(), the system function to handle
+   // big- and little-endian. This works on both big- and
+   // little-endian machines, but ntoh() is not always available or in
+   // a standard place so it is not used by default. On some CPUs the
+   // code for this is very compact through use of a special swap
+   // instruction.
+
+   return ntohll(uTmp);
+#endif
+
+#else
+   // This is the default code that works on every CPU and every
+   // endianness with no dependency on ntoh().  This works on CPUs
+   // that either allow or do not allow unaligned access. It will
+   // always work, but usually is a little less efficient than ntoh().
    return   ((uint64_t)pResult[0]<<56) +
-   ((uint64_t)pResult[1]<<48) +
-   ((uint64_t)pResult[2]<<40) +
-   ((uint64_t)pResult[3]<<32) +
-   ((uint64_t)pResult[4]<<24) +
-   ((uint64_t)pResult[5]<<16) +
-   ((uint64_t)pResult[6]<<8)  +
-   (uint64_t)pResult[7];
+            ((uint64_t)pResult[1]<<48) +
+            ((uint64_t)pResult[2]<<40) +
+            ((uint64_t)pResult[3]<<32) +
+            ((uint64_t)pResult[4]<<24) +
+            ((uint64_t)pResult[5]<<16) +
+            ((uint64_t)pResult[6]<<8)  +
+            (uint64_t)pResult[7];
+#endif
 }
 
 

--- a/inc/UsefulBuf.h
+++ b/inc/UsefulBuf.h
@@ -61,7 +61,6 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
  =============================================================================*/
 
-
 #ifndef _UsefulBuf_h
 #define _UsefulBuf_h
 

--- a/inc/UsefulBuf.h
+++ b/inc/UsefulBuf.h
@@ -80,6 +80,7 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
  The efficiency improvements are not large, so the main reason really
  is to reduce code size.
+
  */
 
 
@@ -1641,7 +1642,7 @@ static inline void UsefulOutBuf_InsertByte(UsefulOutBuf *me,
    UsefulOutBuf_InsertData(me, &byte, 1, uPos);
 }
 
-   
+
 static inline void UsefulOutBuf_InsertUint16(UsefulOutBuf *me,
                                              uint16_t uInteger16,
                                              size_t uPos)
@@ -1659,7 +1660,6 @@ static inline void UsefulOutBuf_InsertUint16(UsefulOutBuf *me,
    
 #elif defined(USEFULBUF_CONFIG_LITTLE_ENDIAN) && defined(USEFULBUF_CONFIG_BSWAP)
    uint16_t uTmp = __builtin_bswap16(uInteger16);
-   
    pBytes = &uTmp;
 
 #else
@@ -2041,6 +2041,7 @@ static inline uint64_t UsefulInputBuf_GetUint64(UsefulInputBuf *pMe)
    // endianness so this must only be used on little-endian machines.
    
    return __builtin_bswap64(uTmp);
+
    
 #endif
 
@@ -2049,6 +2050,7 @@ static inline uint64_t UsefulInputBuf_GetUint64(UsefulInputBuf *pMe)
    // endianness with no dependency on ntoh().  This works on CPUs
    // that either allow or do not allow unaligned access. It will
    // always work, but usually is a little less efficient than ntoh().
+
    return   ((uint64_t)pResult[0]<<56) +
             ((uint64_t)pResult[1]<<48) +
             ((uint64_t)pResult[2]<<40) +

--- a/inc/qcbor.h
+++ b/inc/qcbor.h
@@ -2459,13 +2459,13 @@ void QCBOREncode_CloseMapOrArray(QCBOREncodeContext *pCtx, uint8_t uMajorType, U
  */
 void  QCBOREncode_AddType7(QCBOREncodeContext *pCtx, size_t uSize, uint64_t uNum);
 
-    
+
 /**
  @brief Semi-private method to add only the type and length of a byte string.
- 
+
  @param[in] pCtx    The context to initialize.
  @param[in] Bytes   Pointer and length of the input data.
- 
+
  This is the same as QCBOREncode_AddBytes() except it only adds the
  CBOR encoding for the type and the length. It doesn't actually add
  the bytes. You can't actually produce correct CBOR with this and the
@@ -2476,7 +2476,7 @@ void  QCBOREncode_AddType7(QCBOREncodeContext *pCtx, size_t uSize, uint64_t uNum
  separately and then the bytes is hashed. This makes it possible to
  implement COSE Sign1 with only one copy of the payload in the output
  buffer, rather than two, roughly cutting memory use in half.
- 
+
  This is only used for this odd case, but this is a supported
  tested function.
 */
@@ -2487,7 +2487,7 @@ static inline void QCBOREncode_AddBytesLenOnlyToMap(QCBOREncodeContext *pCtx, co
 static inline void QCBOREncode_AddBytesLenOnlyToMapN(QCBOREncodeContext *pCtx, int64_t nLabel, UsefulBufC Bytes);
 
 
-   
+
 
 static inline void QCBOREncode_AddInt64ToMap(QCBOREncodeContext *pCtx, const char *szLabel, int64_t uNum)
 {


### PR DESCRIPTION
This adds some #define configuration options for compiler/OS/CPU specific endian conversion, particularly hton() or bswap(). As before, everything automatically works correctly without any configuration, but now with some #defines the code for adding integers and floats can be smaller and a little faster on some systems. See comments in UsefulBuf.h