### PR TITLE
Fixes #36: Added 'all' target to Makefile; fixed typos.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ dkms.conf
 
 # Compiled binaries
 qcbortest
+qcbormin
+

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,13 @@ CFLAGS=-I inc -I test -Os
 
 QCBOR_OBJ=src/UsefulBuf.o src/qcbor_encode.o src/qcbor_decode.o src/ieee754.o
 
-TEST_OBJ=test/UsefulBuf_Tests.o test/qcbor_encode_tests.o test/qcbor_decode_tests.o test/run_tests.o \
-  test/float_tests.o test/half_to_double_from_rfc7049.o
+TEST_OBJ=test/UsefulBuf_Tests.o test/qcbor_encode_tests.o \
+    test/qcbor_decode_tests.o test/run_tests.o \
+    test/float_tests.o test/half_to_double_from_rfc7049.o
+
+.PHONY: all install clean
+
+all: qcbortest qcbormin libqcbor.a
 
 qcbortest: libqcbor.a $(TEST_OBJ) cmd_line_main.o
 	$(CC) -o $@ $^  libqcbor.a
@@ -28,30 +33,30 @@ qcbormin: libqcbor.a min_use_main.o
 libqcbor.a: $(QCBOR_OBJ)
 	ar -r $@ $^
 
-PUBLIC_INTERFACE=inc/qcbor/Usefulbuf.h inc/qcbor/qcbor_private.h inc/qcbor/qcbor_common.h inc/qcbor/qcbor_encode.h inc/qcbor/qcbor_decode.h
+PUBLIC_INTERFACE=inc/qcbor/UsefulBuf.h inc/qcbor/qcbor_private.h inc/qcbor/qcbor_common.h inc/qcbor/qcbor_encode.h inc/qcbor/qcbor_decode.h
 
-src/UsefulBuf.o:	inc/UsefulBuf.h
-src/qcbor_decode.o:	inc/qcbor/UsefulBuf.h inc/qcbor/qcbor_private.h inc/qcbor/qcbor_common.h inc/qcbor/qcbor_encode.h src/ieee754.h
-src/qcbor_encode.o:	inc/qcbor/UsefulBuf.h inc/qcbor/qcbor_private.h inc/qcbor/qcbor_common.h inc/qcbor/qcbor_decode.h src/ieee754.h
-src/iee754.o:	src/ieee754.h
+src/UsefulBuf.o: inc/qcbor/UsefulBuf.h
+src/qcbor_decode.o: inc/qcbor/UsefulBuf.h inc/qcbor/qcbor_private.h inc/qcbor/qcbor_common.h inc/qcbor/qcbor_encode.h src/ieee754.h
+src/qcbor_encode.o: inc/qcbor/UsefulBuf.h inc/qcbor/qcbor_private.h inc/qcbor/qcbor_common.h inc/qcbor/qcbor_decode.h src/ieee754.h
+src/iee754.o: src/ieee754.h
 
-test/run_tests.o:	test/UsefulBuf_Tests.h test/float_tests.h test/run_tests.h test/qcbor_encode_tests.h\
+test/run_tests.o: test/UsefulBuf_Tests.h test/float_tests.h test/run_tests.h test/qcbor_encode_tests.h\
     test/qcbor_decode_tests.h
-test/UsefulBuf_Tests.o:	test/UsefulBuf_Tests.h inc/UsefulBuf.h
-test/qcbor_encode_tests.o:	test/qcbor_encode_tests.h $(PUBLIC_INTERFACE) 
-test/qcbor_decode_tests.o:	test/qcbor_decode_tests.h $(PUBIC_INTERFACE)
-test/float_tests.o:	test/float_tests.h test/half_to_double_from_rfc7049.h $(PUBLIC_INTERFACE)
-test/half_to_double_from_rfc7049.o:	test/half_to_double_from_rfc7049.h
+test/UsefulBuf_Tests.o: test/UsefulBuf_Tests.h inc/qcbor/UsefulBuf.h
+test/qcbor_encode_tests.o: test/qcbor_encode_tests.h $(PUBLIC_INTERFACE) 
+test/qcbor_decode_tests.o: test/qcbor_decode_tests.h $(PUBLIC_INTERFACE)
+test/float_tests.o: test/float_tests.h test/half_to_double_from_rfc7049.h $(PUBLIC_INTERFACE)
+test/half_to_double_from_rfc7049.o: test/half_to_double_from_rfc7049.h
 
-cmd_line_main.o:	test/run_tests.h $(PUBLIC_INTERFACE)
+cmd_line_main.o: test/run_tests.h $(PUBLIC_INTERFACE)
 
-min_use_main.o:		$(PUBLIC_INTERFACE)
+min_use_main.o: $(PUBLIC_INTERFACE)
 
 ifeq ($(PREFIX),)
     PREFIX := /usr/local
 endif
 
-install: libqcbor.a
+install: libqcbor.a $(PUBLIC_INTERFACE)
 	install -d $(DESTDIR)$(PREFIX)/lib/
 	install -m 644 libqcbor.a $(DESTDIR)$(PREFIX)/lib/
 	install -d $(DESTDIR)$(PREFIX)/include/qcbor


### PR DESCRIPTION
* Fixed all typos. Now everything builds and correctly.
* Added 'all' target, so that `qcbormin` now is built, too.
* Adapted gitignore to ignore `qcbormin`.
* Minor fixes (replaced tabs with spaces where appropriate).

Signed-off-by: Michael Eckel <michael.eckel@sit.fraunhofer.de>