### PR TITLE
#38 build and install shared objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 
 CC=cc
 
-CFLAGS=-I inc -I test -Os 
+CFLAGS=-I inc -I test -Os -fPIC
 
 
 
@@ -22,7 +22,7 @@ TEST_OBJ=test/UsefulBuf_Tests.o test/qcbor_encode_tests.o \
 
 .PHONY: all install clean
 
-all: qcbortest qcbormin libqcbor.a
+all: qcbortest qcbormin libqcbor.a libqcbor.so
 
 qcbortest: libqcbor.a $(TEST_OBJ) cmd_line_main.o
 	$(CC) -o $@ $^  libqcbor.a
@@ -33,6 +33,9 @@ qcbormin: libqcbor.a min_use_main.o
 libqcbor.a: $(QCBOR_OBJ)
 	ar -r $@ $^
 
+libqcbor.so: $(QCBOR_OBJ)
+		$(CC) $^ $(CFLAGS) -dead_strip -o $@ -shared
+
 PUBLIC_INTERFACE=inc/qcbor/UsefulBuf.h inc/qcbor/qcbor_private.h inc/qcbor/qcbor_common.h inc/qcbor/qcbor_encode.h inc/qcbor/qcbor_decode.h
 
 src/UsefulBuf.o: inc/qcbor/UsefulBuf.h
@@ -40,10 +43,9 @@ src/qcbor_decode.o: inc/qcbor/UsefulBuf.h inc/qcbor/qcbor_private.h inc/qcbor/qc
 src/qcbor_encode.o: inc/qcbor/UsefulBuf.h inc/qcbor/qcbor_private.h inc/qcbor/qcbor_common.h inc/qcbor/qcbor_decode.h src/ieee754.h
 src/iee754.o: src/ieee754.h
 
-test/run_tests.o: test/UsefulBuf_Tests.h test/float_tests.h test/run_tests.h test/qcbor_encode_tests.h\
-    test/qcbor_decode_tests.h
+test/run_tests.o: test/UsefulBuf_Tests.h test/float_tests.h test/run_tests.h test/qcbor_encode_tests.h test/qcbor_decode_tests.h
 test/UsefulBuf_Tests.o: test/UsefulBuf_Tests.h inc/qcbor/UsefulBuf.h
-test/qcbor_encode_tests.o: test/qcbor_encode_tests.h $(PUBLIC_INTERFACE) 
+test/qcbor_encode_tests.o: test/qcbor_encode_tests.h $(PUBLIC_INTERFACE)
 test/qcbor_decode_tests.o: test/qcbor_decode_tests.h $(PUBLIC_INTERFACE)
 test/float_tests.o: test/float_tests.h test/half_to_double_from_rfc7049.h $(PUBLIC_INTERFACE)
 test/half_to_double_from_rfc7049.o: test/half_to_double_from_rfc7049.h
@@ -56,16 +58,25 @@ ifeq ($(PREFIX),)
     PREFIX := /usr/local
 endif
 
-install: libqcbor.a $(PUBLIC_INTERFACE)
+install: libqcbor.a libqcbor.so $(PUBLIC_INTERFACE)
 	install -d $(DESTDIR)$(PREFIX)/lib/
 	install -m 644 libqcbor.a $(DESTDIR)$(PREFIX)/lib/
+	install -m 755 libqcbor.so $(DESTDIR)$(PREFIX)/lib/libqcbor.so.1.0.0
+	ln -sf libqcbor.so.1 $(DESTDIR)$(PREFIX)/lib/libqcbor.so
+	ln -sf libqcbor.so.1.0.0 $(DESTDIR)$(PREFIX)/lib/libqcbor.so.1
 	install -d $(DESTDIR)$(PREFIX)/include/qcbor
-	install -m 644 inc/qcbor.h $(DESTDIR)$(PREFIX)/include/qcbor
+	install -m 644 inc/qcbor/qcbor.h $(DESTDIR)$(PREFIX)/include/qcbor
 	install -m 644 inc/qcbor/qcbor_private.h $(DESTDIR)$(PREFIX)/include/qcbor
 	install -m 644 inc/qcbor/qcbor_common.h $(DESTDIR)$(PREFIX)/include/qcbor
 	install -m 644 inc/qcbor/qcbor_decode.h $(DESTDIR)$(PREFIX)/include/qcbor
 	install -m 644 inc/qcbor/qcbor_encode.h $(DESTDIR)$(PREFIX)/include/qcbor
 	install -m 644 inc/qcbor/UsefulBuf.h $(DESTDIR)$(PREFIX)/include/qcbor
+
+uninstall: libqcbor.a $(PUBLIC_INTERFACE)
+	$(RM) -d $(DESTDIR)$(PREFIX)/include/qcbor/*
+	$(RM) -d $(DESTDIR)$(PREFIX)/include/qcbor/
+	$(RM) $(addprefix $(DESTDIR)$(PREFIX)/lib/, \
+		libqcbor.a libqcbor.so libqcbor.so.1 libqcbor.so.1.0.0)
 
 clean:
 	rm -f $(QCBOR_OBJ) $(TEST_OBJ) libqcbor.a min_use_main.o cmd_line_main.o

--- a/inc/qcbor/qcbor.h
+++ b/inc/qcbor/qcbor.h
@@ -1,0 +1,41 @@
+/*==============================================================================
+ Copyright (c) 2016-2018, The Linux Foundation.
+ Copyright (c) 2018-2020, Laurence Lundblade.
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are
+ met:
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above
+ copyright notice, this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of The Linux Foundation nor the names of its
+ contributors, nor the name "Laurence Lundblade" may be used to
+ endorse or promote products derived from this software without
+ specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ =============================================================================*/
+
+/**
+ * @file qcbor.h
+ *
+ * Backwards compatibility for includers of qcbor.h (which has been split
+ * into four include files).
+ */
+
+#include "qcbor_encode.h"
+#include "qcbor_decode.h"

--- a/min_use_main.c
+++ b/min_use_main.c
@@ -31,7 +31,7 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //  Created by Laurence Lundblade on 10/26/18.
 
 #include <stdio.h>
-#include "qcbor.h"
+#include "qcbor/qcbor.h"
 
 
 


### PR DESCRIPTION
Fixes #38: Added shared object build + uninstall.
* Added functionality to build the library as shared object (*.so). Needed to add "-fPIC" compile option for that purpose.
* Further, added install logic for shared object.
* Added uninstall logic for all installed files (`*.so*`, `*.a`, and `*.h`).
  * I assumed the library to be in version 1.0.0 and created symbolic links accordingly:

    ```
    -rw-r--r-- 1 root root    21K Mar  5 11:28 AM libqcbor.a
    lrwxrwxrwx 1 root root     13 Mar  5 11:28 AM libqcbor.so -> libqcbor.so.1
    lrwxrwxrwx 1 root root     17 Mar  5 11:28 AM libqcbor.so.1 -> libqcbor.so.1.0.0
    -rwxr-xr-x 1 root root    23K Mar  5 11:28 AM libqcbor.so.1.0.0
    ```

PS: I also moved the `qcbor.h` include file to the `qcbor` subfolder and created a reference from the original `qcbor.h` to it. Then I adapted all paths where it was necessary (Makefile, the `qcbor.h` files themselves, and `min_use_main.c`, which referenced it).

@laurencelundblade Please test whether it compiles, installs, and uninstalls on your system, first. On my Ubuntu 18.04 machine it does. Thanks :-)