### PR TITLE
Fix bad headers when used from C++

### DIFF
--- a/inc/qcbor/qcbor_decode.h
+++ b/inc/qcbor/qcbor_decode.h
@@ -42,7 +42,7 @@
 
 #ifdef __cplusplus
 extern "C" {
-#ifdef 0
+#if 0
 } // Keep editor indention formatting happy
 #endif
 #endif
@@ -936,5 +936,8 @@ static inline int QCBOR_Int64ToUInt64(int64_t src, uint64_t *dest)
    return 0;
 }
 
+#ifdef __cplusplus
+}
+#endif 
 
 #endif /* qcbor_decode_h */

--- a/inc/qcbor/qcbor_encode.h
+++ b/inc/qcbor/qcbor_encode.h
@@ -42,7 +42,7 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef __cplusplus
 extern "C" {
-#ifdef 0
+#if 0
 } // Keep editor indention formatting happy
 #endif
 #endif

--- a/inc/qcbor/qcbor_private.h
+++ b/inc/qcbor/qcbor_private.h
@@ -41,7 +41,7 @@
 
 #ifdef __cplusplus
 extern "C" {
-#ifdef 0
+#if 0
 } // Keep editor indention formatting happy
 #endif
 #endif
@@ -181,5 +181,8 @@ struct _QCBORDecodeContext {
 #define CBOR_MAJOR_NONE_TYPE_ARRAY_INDEFINITE_LEN 12
 #define CBOR_MAJOR_NONE_TYPE_MAP_INDEFINITE_LEN 13
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* qcbor_private_h */


### PR DESCRIPTION
Without this fix, including the headers from a C++ app hits syntax errors.

Tested compilation with both gcc (using the Makefile) and clang
(which is needed to compile the code into an enclave usable
with the Open Enclave SDK).

Signed-off-by: Dave Thaler <dthaler@microsoft.com>