### PR TITLE
Fix 3 compilation warnings with GCC 10

### DIFF
--- a/src/qcbor_decode.c
+++ b/src/qcbor_decode.c
@@ -715,9 +715,9 @@ static QCBORError GetNext_Item(UsefulInputBuf *pUInBuf,
     an encoding of the length of the uNumber and is needed to decode
     floats and doubles
    */
-   int      nMajorType;
-   uint64_t uNumber;
-   int      nAdditionalInfo;
+   int      nMajorType = 0;
+   uint64_t uNumber = 0;
+   int      nAdditionalInfo = 0;
 
    memset(pDecodedItem, 0, sizeof(QCBORItem));
 


### PR DESCRIPTION
GCC 10 generates a warning about three variables possibly being used
without being initialised.  This patch gives those variables initial
values to suppress this warning.