### PR TITLE
add link with -lm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@
 CC=cc
 #CC=/usr/local/bin/gcc-9
 
+LIBS=-lm
 CFLAGS=$(CMD_LINE) -I inc -I test -Os -fPIC 
 
 # The following are used before a release of QCBOR help to make sure
@@ -31,7 +32,7 @@ all: qcbortest libqcbor.a
 so:	libqcbor.so
 
 qcbortest: libqcbor.a $(TEST_OBJ) cmd_line_main.o
-	$(CC) -o $@ $^  libqcbor.a
+	$(CC) -o $@ $(LIBS) $^  libqcbor.a
 
 libqcbor.a: $(QCBOR_OBJ)
 	ar -r $@ $^


### PR DESCRIPTION
Hi,

Building from source on GNU/Linux result with the following errors:
```
$ make                                                                                                                                                                                                                                                                       
cc  -I inc -I test -Os -fPIC    -c -o src/UsefulBuf.o src/UsefulBuf.c
cc  -I inc -I test -Os -fPIC    -c -o src/qcbor_encode.o src/qcbor_encode.c
cc  -I inc -I test -Os -fPIC    -c -o src/qcbor_decode.o src/qcbor_decode.c
cc  -I inc -I test -Os -fPIC    -c -o src/ieee754.o src/ieee754.c
cc  -I inc -I test -Os -fPIC    -c -o src/qcbor_err_to_str.o src/qcbor_err_to_str.c
ar -r libqcbor.a src/UsefulBuf.o src/qcbor_encode.o src/qcbor_decode.o src/ieee754.o src/qcbor_err_to_str.o
ar: creating libqcbor.a
cc  -I inc -I test -Os -fPIC    -c -o test/UsefulBuf_Tests.o test/UsefulBuf_Tests.c
cc  -I inc -I test -Os -fPIC    -c -o test/qcbor_encode_tests.o test/qcbor_encode_tests.c
cc  -I inc -I test -Os -fPIC    -c -o test/qcbor_decode_tests.o test/qcbor_decode_tests.c
cc  -I inc -I test -Os -fPIC    -c -o test/run_tests.o test/run_tests.c
cc  -I inc -I test -Os -fPIC    -c -o test/float_tests.o test/float_tests.c
cc  -I inc -I test -Os -fPIC    -c -o test/half_to_double_from_rfc7049.o test/half_to_double_from_rfc7049.c
cc  -I inc -I test -Os -fPIC    -c -o example.o example.c
cc  -I inc -I test -Os -fPIC    -c -o cmd_line_main.o cmd_line_main.c
cc -o qcbortest libqcbor.a test/UsefulBuf_Tests.o test/qcbor_encode_tests.o test/qcbor_decode_tests.o test/run_tests.o test/float_tests.o test/half_to_double_from_rfc7049.o example.o cmd_line_main.o  libqcbor.a
/usr/bin/ld: libqcbor.a(qcbor_decode.o): in function `DoubleConvertAll':
qcbor_decode.c:(.text+0x269): undefined reference to `exp2'
/usr/bin/ld: qcbor_decode.c:(.text+0x2fb): undefined reference to `pow'
/usr/bin/ld: qcbor_decode.c:(.text+0x335): undefined reference to `pow'
/usr/bin/ld: qcbor_decode.c:(.text+0x394): undefined reference to `exp2'
/usr/bin/ld: libqcbor.a(qcbor_decode.o): in function `ConvertInt64':
qcbor_decode.c:(.text+0x49b): undefined reference to `feclearexcept'
/usr/bin/ld: qcbor_decode.c:(.text+0x4aa): undefined reference to `llround'
/usr/bin/ld: qcbor_decode.c:(.text+0x4b6): undefined reference to `lroundf'
/usr/bin/ld: qcbor_decode.c:(.text+0x4c4): undefined reference to `fetestexcept'
/usr/bin/ld: libqcbor.a(qcbor_decode.o): in function `ConvertUInt64':
qcbor_decode.c:(.text+0x558): undefined reference to `feclearexcept'
/usr/bin/ld: qcbor_decode.c:(.text+0x585): undefined reference to `round'
/usr/bin/ld: qcbor_decode.c:(.text+0x5cf): undefined reference to `roundf'
/usr/bin/ld: qcbor_decode.c:(.text+0x60f): undefined reference to `fetestexcept'
collect2: error: ld returned 1 exit status
make: *** [Makefile:34: qcbortest] Error 1

```

Some info:

```
$ gcc -v                                                                                                                                                                                                                                                                     
Reading specs from /usr/lib64/gcc/x86_64-slackware-linux/9.3.0/specs
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/libexec/gcc/x86_64-slackware-linux/9.3.0/lto-wrapper
Target: x86_64-slackware-linux
Configured with: ../configure --prefix=/usr --libdir=/usr/lib64 --mandir=/usr/man --infodir=/usr/info --enable-shared --enable-bootstrap --enable-languages=ada,brig,c,c++,d,fortran,go,lto,objc,obj-c++ --enable-threads=posix --enable-checking=release --enable-objc-gc --with-system-zlib --enable-libstdcxx-dual-abi --with-default-libstdcxx-abi=new --disable-libstdcxx-pch --disable-libunwind-exceptions --enable-__cxa_atexit --disable-libssp --enable-gnu-unique-object --enable-plugin --enable-lto --disable-install-libiberty --disable-werror --with-gnu-ld --with-isl --verbose --with-arch-directory=amd64 --disable-gtktest --enable-clocale=gnu --disable-multilib --target=x86_64-slackware-linux --build=x86_64-slackware-linux --host=x86_64-slackware-linux
Thread model: posix
gcc version 9.3.0 (GCC)
```

Build successfully when linking with math library.
