### PR TITLE
Option to disable indefinite length string decoding

### DIFF
--- a/QCBOR.xcodeproj/project.pbxproj
+++ b/QCBOR.xcodeproj/project.pbxproj
@@ -56,6 +56,19 @@
 		E776E091214AE07500E67947 /* qcbor_decode.c in Sources */ = {isa = PBXBuildFile; fileRef = E776E08E214AE07500E67947 /* qcbor_decode.c */; };
 		E776E097214AE0C700E67947 /* cmd_line_main.c in Sources */ = {isa = PBXBuildFile; fileRef = E776E096214AE0C700E67947 /* cmd_line_main.c */; };
 		E7864766252CE63100A0C11B /* qcbor_err_to_str.c in Sources */ = {isa = PBXBuildFile; fileRef = E7864765252CE63100A0C11B /* qcbor_err_to_str.c */; };
+		E7FDBF04256C969D007138A8 /* qcbor_encode.c in Sources */ = {isa = PBXBuildFile; fileRef = E776E08C214AE07400E67947 /* qcbor_encode.c */; };
+		E7FDBF05256C969D007138A8 /* ieee754.c in Sources */ = {isa = PBXBuildFile; fileRef = E73B57582161CA690080D658 /* ieee754.c */; };
+		E7FDBF06256C969D007138A8 /* qcbor_err_to_str.c in Sources */ = {isa = PBXBuildFile; fileRef = E7864765252CE63100A0C11B /* qcbor_err_to_str.c */; };
+		E7FDBF07256C969D007138A8 /* half_to_double_from_rfc7049.c in Sources */ = {isa = PBXBuildFile; fileRef = E73B575D2161CA7C0080D658 /* half_to_double_from_rfc7049.c */; };
+		E7FDBF08256C969D007138A8 /* run_tests.c in Sources */ = {isa = PBXBuildFile; fileRef = E73B57632161F8F70080D658 /* run_tests.c */; };
+		E7FDBF09256C969D007138A8 /* qcbor_decode.c in Sources */ = {isa = PBXBuildFile; fileRef = E776E08E214AE07500E67947 /* qcbor_decode.c */; };
+		E7FDBF0A256C969D007138A8 /* float_tests.c in Sources */ = {isa = PBXBuildFile; fileRef = E73B575A2161CA7C0080D658 /* float_tests.c */; };
+		E7FDBF0B256C969D007138A8 /* qcbor_decode_tests.c in Sources */ = {isa = PBXBuildFile; fileRef = 0FA9BEB5216CE6CA00BA646B /* qcbor_decode_tests.c */; };
+		E7FDBF0C256C969D007138A8 /* UsefulBuf.c in Sources */ = {isa = PBXBuildFile; fileRef = E776E08D214AE07500E67947 /* UsefulBuf.c */; };
+		E7FDBF0D256C969D007138A8 /* qcbor_encode_tests.c in Sources */ = {isa = PBXBuildFile; fileRef = 0FA9BEB8216DC7AD00BA646B /* qcbor_encode_tests.c */; };
+		E7FDBF0E256C969D007138A8 /* cmd_line_main.c in Sources */ = {isa = PBXBuildFile; fileRef = E776E096214AE0C700E67947 /* cmd_line_main.c */; };
+		E7FDBF0F256C969D007138A8 /* example.c in Sources */ = {isa = PBXBuildFile; fileRef = E743D0E124AC516D0017899F /* example.c */; };
+		E7FDBF10256C969D007138A8 /* UsefulBuf_Tests.c in Sources */ = {isa = PBXBuildFile; fileRef = 0FA9BEBC216DE31700BA646B /* UsefulBuf_Tests.c */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -87,6 +100,15 @@
 			runOnlyForDeploymentPostprocessing = 1;
 		};
 		E776E07A214ADF7F00E67947 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+		E7FDBF12256C969D007138A8 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = /usr/share/man/man1/;
@@ -134,6 +156,7 @@
 		E78C91DF240C90C100F4CECE /* qcbor_common.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 3; lastKnownFileType = sourcecode.c.h; name = qcbor_common.h; path = inc/qcbor/qcbor_common.h; sourceTree = "<group>"; tabWidth = 3; };
 		E78C91E0240C90C100F4CECE /* qcbor_private.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 3; lastKnownFileType = sourcecode.c.h; name = qcbor_private.h; path = inc/qcbor/qcbor_private.h; sourceTree = "<group>"; tabWidth = 3; };
 		E78C91E1240C90C100F4CECE /* qcbor_encode.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 3; lastKnownFileType = sourcecode.c.h; name = qcbor_encode.h; path = inc/qcbor/qcbor_encode.h; sourceTree = "<group>"; tabWidth = 3; };
+		E7FDBF16256C969D007138A8 /* QCBOR_Disable_Indef */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = QCBOR_Disable_Indef; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -159,6 +182,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		E776E079214ADF7F00E67947 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E7FDBF11256C969D007138A8 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -199,6 +229,7 @@
 				E772022723B52C02006E966E /* QCBOR_Disable_Exp_Mantissa */,
 				E743D11B24DD4EF50017899F /* QCBOR_Disable_HW_Float */,
 				E743D13124DE05CC0017899F /* QCBOR_Disable_Preferred_Float */,
+				E7FDBF16256C969D007138A8 /* QCBOR_Disable_Indef */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -321,6 +352,23 @@
 			productReference = E776E07C214ADF7F00E67947 /* QCBOR */;
 			productType = "com.apple.product-type.tool";
 		};
+		E7FDBF02256C969D007138A8 /* QCBOR_Disable_Indef */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E7FDBF13256C969D007138A8 /* Build configuration list for PBXNativeTarget "QCBOR_Disable_Indef" */;
+			buildPhases = (
+				E7FDBF03256C969D007138A8 /* Sources */,
+				E7FDBF11256C969D007138A8 /* Frameworks */,
+				E7FDBF12256C969D007138A8 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = QCBOR_Disable_Indef;
+			productName = QCBOR;
+			productReference = E7FDBF16256C969D007138A8 /* QCBOR_Disable_Indef */;
+			productType = "com.apple.product-type.tool";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -352,6 +400,7 @@
 				E772021523B52C02006E966E /* QCBOR_Disable_Exp_Mantissa */,
 				E743D10924DD4EF50017899F /* QCBOR_Disable_HW_Float */,
 				E743D11E24DE05CC0017899F /* QCBOR_Disable_Preferred_Float */,
+				E7FDBF02256C969D007138A8 /* QCBOR_Disable_Indef */,
 			);
 		};
 /* End PBXProject section */
@@ -431,6 +480,26 @@
 				E776E097214AE0C700E67947 /* cmd_line_main.c in Sources */,
 				E743D0F324AD08020017899F /* example.c in Sources */,
 				0FA9BEBD216DE31700BA646B /* UsefulBuf_Tests.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E7FDBF03256C969D007138A8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E7FDBF04256C969D007138A8 /* qcbor_encode.c in Sources */,
+				E7FDBF05256C969D007138A8 /* ieee754.c in Sources */,
+				E7FDBF06256C969D007138A8 /* qcbor_err_to_str.c in Sources */,
+				E7FDBF07256C969D007138A8 /* half_to_double_from_rfc7049.c in Sources */,
+				E7FDBF08256C969D007138A8 /* run_tests.c in Sources */,
+				E7FDBF09256C969D007138A8 /* qcbor_decode.c in Sources */,
+				E7FDBF0A256C969D007138A8 /* float_tests.c in Sources */,
+				E7FDBF0B256C969D007138A8 /* qcbor_decode_tests.c in Sources */,
+				E7FDBF0C256C969D007138A8 /* UsefulBuf.c in Sources */,
+				E7FDBF0D256C969D007138A8 /* qcbor_encode_tests.c in Sources */,
+				E7FDBF0E256C969D007138A8 /* cmd_line_main.c in Sources */,
+				E7FDBF0F256C969D007138A8 /* example.c in Sources */,
+				E7FDBF10256C969D007138A8 /* UsefulBuf_Tests.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -670,6 +739,35 @@
 			};
 			name = Release;
 		};
+		E7FDBF14256C969D007138A8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_UNDEFINED_BEHAVIOR_SANITIZER_INTEGER = YES;
+				CLANG_UNDEFINED_BEHAVIOR_SANITIZER_NULLABILITY = YES;
+				CODE_SIGN_STYLE = Automatic;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS;
+				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
+				GCC_WARN_PEDANTIC = YES;
+				"HEADER_SEARCH_PATHS[arch=*]" = inc;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		E7FDBF15256C969D007138A8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_UNDEFINED_BEHAVIOR_SANITIZER_INTEGER = YES;
+				CLANG_UNDEFINED_BEHAVIOR_SANITIZER_NULLABILITY = YES;
+				CODE_SIGN_STYLE = Automatic;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
+				GCC_WARN_PEDANTIC = YES;
+				"HEADER_SEARCH_PATHS[arch=*]" = inc;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -714,6 +812,15 @@
 			buildConfigurations = (
 				E776E084214ADF7F00E67947 /* Debug */,
 				E776E085214ADF7F00E67947 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E7FDBF13256C969D007138A8 /* Build configuration list for PBXNativeTarget "QCBOR_Disable_Indef" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E7FDBF14256C969D007138A8 /* Debug */,
+				E7FDBF15256C969D007138A8 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/README.md
+++ b/README.md
@@ -231,8 +231,8 @@ These are approximate sizes on a 64-bit x86 CPU with the -Os optimization.
     |               | smallest | largest |  
     |---------------|----------|---------|
     | encode only   |      850 |    2100 |
-    | decode only   |     2900 |   13500 |
-    | combined      |     3750 |   15600 |
+    | decode only   |     2500 |   13500 |
+    | combined      |     3350 |   15600 |
     
  From the table above, one can see that the amount of code pulled in
  from the QCBOR library varies a lot, ranging from 1KB to 15KB.  The
@@ -273,8 +273,9 @@ These are approximate sizes on a 64-bit x86 CPU with the -Os optimization.
  Disable features with defines like
  QCBOR_CONFIG_DISABLE_EXP_AND_MANTISSA (saves about 400 bytes) 
  QCBOR_DISABLE_ENCODE_USAGE_GUARDS (saves about 150), and
- QCBOR_DISABLE_PREFERRED_FLOAT (saves about 900 bytes).  More of these
- defines are planned than are currently implemented.
+ QCBOR_DISABLE_PREFERRED_FLOAT (saves about 900 bytes), and
+ QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS (saves about 400 bytes).  More
+  of these defines are planned than are currently implemented.
  
  If QCBOR is installed as a shared library, then of course only one
  copy of the code is in memory no matter how many applications use it.

--- a/inc/qcbor/qcbor_common.h
+++ b/inc/qcbor/qcbor_common.h
@@ -468,7 +468,6 @@ typedef enum {
        attempted. */
    QCBOR_ERR_FLOAT_EXCEPTION = 42,
 
-
    /** Indefinite length string handling is disabled and there is an
        indefinite length string in the input CBOR. */
    QCBOR_ERR_INDEF_LEN_STRINGS_DISABLED = 43,

--- a/inc/qcbor/qcbor_common.h
+++ b/inc/qcbor/qcbor_common.h
@@ -466,7 +466,11 @@ typedef enum {
        infinity or -infinity was encountered in encoded CBOR. Usually
        this because conversion of the float-point value was being
        attempted. */
-    QCBOR_ERR_FLOAT_EXCEPTION = 42,
+   QCBOR_ERR_FLOAT_EXCEPTION = 42,
+
+
+   /** Indefinite length string handling is disabled and there is an indefinite length string in the input CBOR. */
+   QCBOR_ERR_INDEF_LEN_STRINGS_DISABLED = 43,
 
    /* This is stored in uint8_t; never add values > 255 */
 } QCBORError;

--- a/inc/qcbor/qcbor_common.h
+++ b/inc/qcbor/qcbor_common.h
@@ -469,7 +469,8 @@ typedef enum {
    QCBOR_ERR_FLOAT_EXCEPTION = 42,
 
 
-   /** Indefinite length string handling is disabled and there is an indefinite length string in the input CBOR. */
+   /** Indefinite length string handling is disabled and there is an
+       indefinite length string in the input CBOR. */
    QCBOR_ERR_INDEF_LEN_STRINGS_DISABLED = 43,
 
    /* This is stored in uint8_t; never add values > 255 */

--- a/inc/qcbor/qcbor_private.h
+++ b/inc/qcbor/qcbor_private.h
@@ -279,9 +279,13 @@ struct _QCBORDecodeContext {
 
 /* Value of QCBORItem.val.string.len when the string length is
  * indefinite. Used temporarily in the implementation and never
- * returned to caller.
+ * returned in the public interface.
  */
 #define QCBOR_STRING_LENGTH_INDEFINITE SIZE_MAX
+
+
+/* The number of elements in a C array of a particular type */
+#define C_ARRAY_COUNT(array, type) (sizeof(array)/sizeof(type))
 
 
 #ifdef __cplusplus

--- a/inc/qcbor/qcbor_private.h
+++ b/inc/qcbor/qcbor_private.h
@@ -276,6 +276,14 @@ struct _QCBORDecodeContext {
 #define CBOR_MAJOR_NONE_TYPE_SIMPLE_BREAK \
             CBOR_MAJOR_TYPE_SIMPLE + QCBOR_INDEFINITE_LEN_TYPE_MODIFIER
 
+
+/* Value of QCBORItem.val.string.len when the string length is
+ * indefinite. Used temporarily in the implementation and never
+ * returned to caller.
+ */
+#define QCBOR_STRING_LENGTH_INDEFINITE SIZE_MAX
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/qcbor_decode.c
+++ b/src/qcbor_decode.c
@@ -516,7 +516,7 @@ StringAllocator_Destruct(const QCORInternalAllocator *pMe)
       (pMe->pfAllocator)(pMe->pAllocateCxt, NULL, 0);
    }
 }
-#endif
+#endif /* QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS */
 
 
 /*===========================================================================
@@ -882,7 +882,7 @@ static inline QCBORError DecodeBytes(const QCORInternalAllocator *pAllocator,
       pDecodedItem->uDataAlloc = 1;
       goto Done;
    }
-#else
+#else /* QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS */
    (void)pAllocator;
 #endif /* QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS */
 
@@ -982,7 +982,7 @@ static QCBORError GetNext_Item(UsefulInputBuf *pUInBuf,
 
       case CBOR_MAJOR_TYPE_BYTE_STRING: // Major type 2
       case CBOR_MAJOR_TYPE_TEXT_STRING: // Major type 3
-         pDecodedItem->uDataType = (uint8_t)MapStringMajorTypes(nMajorType);
+         pDecodedItem->uDataType = MapStringMajorTypes(nMajorType);
          if(nAdditionalInfo == LEN_IS_INDEFINITE) {
             pDecodedItem->val.string = (UsefulBufC){NULL, QCBOR_STRING_LENGTH_INDEFINITE};
          } else {
@@ -1033,31 +1033,30 @@ Done:
 }
 
 
-
 /**
- @brief Process indefinite length strings
-
- @param[in] pMe   Decoder context
- @param[in,out] pDecodedItem  The decoded item that work is done on.
-
- @retval QCBOR_ERR_UNSUPPORTED
- @retval QCBOR_ERR_HIT_END
- @retval QCBOR_ERR_INT_OVERFLOW
- @retval QCBOR_ERR_STRING_ALLOCATE
- @retval QCBOR_ERR_STRING_TOO_LONG
- @retval QCBOR_ERR_HALF_PRECISION_DISABLED
- @retval QCBOR_ERR_BAD_TYPE_7
- @retval QCBOR_ERR_NO_STRING_ALLOCATOR
- @retval QCBOR_ERR_INDEFINITE_STRING_CHUNK
-
- If @c pDecodedItem is not an indefinite length string, this does nothing.
-
- If it is, this loops getting the subsequent chunks that make up the
- string.  The string allocator is used to make a contiguous buffer for
- the chunks.  When this completes @c pDecodedItem contains the
- put-together string.
-
- Code Reviewers: THIS FUNCTION DOES A LITTLE POINTER MATH
+ * @brief Process indefinite length strings
+ *
+ * @param[in] pMe   Decoder context
+ * @param[in,out] pDecodedItem  The decoded item that work is done on.
+ *
+ * @retval QCBOR_ERR_UNSUPPORTED
+ * @retval QCBOR_ERR_HIT_END
+ * @retval QCBOR_ERR_INT_OVERFLOW
+ * @retval QCBOR_ERR_STRING_ALLOCATE
+ * @retval QCBOR_ERR_STRING_TOO_LONG
+ * @retval QCBOR_ERR_HALF_PRECISION_DISABLED
+ * @retval QCBOR_ERR_BAD_TYPE_7
+ * @retval QCBOR_ERR_NO_STRING_ALLOCATOR
+ * @retval QCBOR_ERR_INDEFINITE_STRING_CHUNK
+ *
+ * If @c pDecodedItem is not an indefinite length string, this does nothing.
+ *
+ * If it is, this loops getting the subsequent chunks that make up the
+ * string.  The string allocator is used to make a contiguous buffer for
+ * the chunks.  When this completes @c pDecodedItem contains the
+ * put-together string.
+ *
+ * Code Reviewers: THIS FUNCTION DOES A LITTLE POINTER MATH
  */
 static inline QCBORError
 GetNext_FullItem(QCBORDecodeContext *pMe, QCBORItem *pDecodedItem)
@@ -1098,7 +1097,7 @@ GetNext_FullItem(QCBORDecodeContext *pMe, QCBORItem *pDecodedItem)
          pAllocatorForGetNext = pAllocator;
       }
    }
-#endif
+#endif /* QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS */
 
    QCBORError uReturn;
    uReturn = GetNext_Item(&(pMe->InBuf), pDecodedItem, pAllocatorForGetNext);
@@ -1180,7 +1179,7 @@ GetNext_FullItem(QCBORDecodeContext *pMe, QCBORItem *pDecodedItem)
       /* Getting the item failed, clean up the allocated memory */
       StringAllocator_Free(pAllocator, UNCONST_POINTER(FullString.ptr));
    }
-#else
+#else /* QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS */
    uReturn = QCBOR_ERR_INDEF_LEN_STRINGS_DISABLED;
 #endif /* QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS */
 
@@ -2253,7 +2252,7 @@ Done:
    // Call the destructor for the string allocator if there is one.
    // Always called, even if there are errors; always have to clean up
    StringAllocator_Destruct(&(me->StringAllocator));
-#endif
+#endif /* QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS */
 
    return uReturn;
 }
@@ -2507,7 +2506,7 @@ QCBORError QCBORDecode_SetMemPool(QCBORDecodeContext *pMe,
 
    return QCBOR_SUCCESS;
 }
-#endif
+#endif /* QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS */
 
 
 

--- a/test/not_well_formed_cbor.h
+++ b/test/not_well_formed_cbor.h
@@ -28,6 +28,7 @@ static const struct someBinaryBytes paNotWellFormedCBOR[] = {
 
     // Indefinite length strings must be closed off
 
+#ifndef QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS
     // An indefinite length byte string not closed off
     {(uint8_t[]){0x5f, 0x41, 0x00}, 3},
     // An indefinite length text string not closed off
@@ -57,6 +58,8 @@ static const struct someBinaryBytes paNotWellFormedCBOR[] = {
     {(uint8_t[]){0x5f, 0x5f, 0x41, 0x00, 0xff, 0xff}, 6},
     // indefinite length text string with indefinite string inside
     {(uint8_t[]){0x7f, 0x7f, 0x61, 0x00, 0xff, 0xff}, 6},
+
+#endif /* QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS */
 
     // Definte length maps and arrays must be closed by having the
     // right number of items

--- a/test/qcbor_decode_tests.c
+++ b/test/qcbor_decode_tests.c
@@ -1635,7 +1635,8 @@ int32_t NotWellFormedTests()
 {
    // Loop over all the not-well-formed instance of CBOR
    // that are test vectors in not_well_formed_cbor.h
-   const uint16_t nArraySize = sizeof(paNotWellFormedCBOR)/sizeof(struct someBinaryBytes);
+   const uint16_t nArraySize = C_ARRAY_COUNT(paNotWellFormedCBOR,
+                                             struct someBinaryBytes);
    for(uint16_t nIterate = 0; nIterate < nArraySize; nIterate++) {
       const struct someBinaryBytes *pBytes = &paNotWellFormedCBOR[nIterate];
       const UsefulBufC Input = (UsefulBufC){pBytes->p, pBytes->n};
@@ -1647,7 +1648,7 @@ int32_t NotWellFormedTests()
 #ifndef QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS
       UsefulBuf_MAKE_STACK_UB(Pool, 100);
       QCBORDecode_SetMemPool(&DCtx, Pool, 0);
-#endif
+#endif /* QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS */
 
       // Loop getting items until no more to get
       QCBORError uCBORError;
@@ -2070,7 +2071,7 @@ int32_t DecodeFailureTests()
 {
    int32_t nResult;
 
-   nResult = ProcessFailures(Failures, sizeof(Failures)/sizeof(struct FailInput));
+   nResult = ProcessFailures(Failures,C_ARRAY_COUNT(Failures,struct FailInput));
    if(nResult) {
       return nResult;
    }
@@ -4653,7 +4654,8 @@ static struct FailInput ExponentAndMantissaFailures[] = {
 int32_t ExponentAndMantissaDecodeFailTests()
 {
    return ProcessFailures(ExponentAndMantissaFailures,
-                          sizeof(ExponentAndMantissaFailures)/sizeof(struct FailInput));
+                          C_ARRAY_COUNT(ExponentAndMantissaFailures,
+                                        struct FailInput));
 }
 
 #endif /* QCBOR_CONFIG_DISABLE_EXP_AND_MANTISSA */
@@ -5450,7 +5452,7 @@ static const struct NumberConversion NumberConversions[] = {
       16909060.0,
       QCBOR_SUCCESS
    },
-#endif
+#endif /* QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS */
    {
       "Decimal Fraction with neg bignum [9223372036854775807, -4759477275222530853137]",
       {(uint8_t[]){0xC4, 0x82, 0x1B, 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
@@ -5854,7 +5856,8 @@ static int32_t SetUpDecoder(QCBORDecodeContext *DCtx, UsefulBufC CBOR, UsefulBuf
 
 int32_t IntegerConvertTest()
 {
-   const int nNumTests = sizeof(NumberConversions)/sizeof(struct NumberConversion);
+   const int nNumTests = C_ARRAY_COUNT(NumberConversions,
+                                       struct NumberConversion);
 
    for(int nIndex = 0; nIndex < nNumTests; nIndex++) {
       const struct NumberConversion *pF = &NumberConversions[nIndex];
@@ -6798,7 +6801,7 @@ int32_t SpiffyIndefiniteLengthStringsTests()
 
    return 0;
 }
-#endif /* #ifndef QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS */
+#endif /* QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS */
 
 
 

--- a/test/run_tests.c
+++ b/test/run_tests.c
@@ -63,7 +63,6 @@ static test_entry s_tests[] = {
     TEST_ENTRY(EmptyMapsAndArraysTest),
     TEST_ENTRY(NotWellFormedTests),
     TEST_ENTRY(ParseMapAsArrayTest),
-    TEST_ENTRY(AllocAllStringsTest),
     TEST_ENTRY(IndefiniteLengthNestTest),
     TEST_ENTRY(NestedMapTestIndefLen),
     TEST_ENTRY(ParseSimpleTest),
@@ -95,8 +94,13 @@ static test_entry s_tests[] = {
     TEST_ENTRY(ParseDeepArrayTest),
     TEST_ENTRY(SimpleArrayTest),
     TEST_ENTRY(IntegerValuesParseTest),
+#ifndef QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS
+    TEST_ENTRY(AllocAllStringsTest),
     TEST_ENTRY(MemPoolTest),
     TEST_ENTRY(IndefiniteLengthStringTest),
+    TEST_ENTRY(SpiffyIndefiniteLengthStringsTests),
+    TEST_ENTRY(SetUpAllocatorTest),
+#endif /* #ifndef QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS */
 #ifndef QCBOR_DISABLE_PREFERRED_FLOAT
     TEST_ENTRY(HalfPrecisionDecodeBasicTests),
     TEST_ENTRY(DoubleAsSmallestTest),
@@ -112,7 +116,6 @@ static test_entry s_tests[] = {
     TEST_ENTRY_DISABLED(BigComprehensiveInputTest),
     TEST_ENTRY_DISABLED(TooLargeInputTest),
     TEST_ENTRY(EncodeErrorTests),
-    TEST_ENTRY(SetUpAllocatorTest),
     TEST_ENTRY(SimpleValuesIndefiniteLengthTest1),
     TEST_ENTRY(EncodeLengthThirtyoneTest),
     TEST_ENTRY(CBORSequenceDecodeTests),
@@ -124,7 +127,6 @@ static test_entry s_tests[] = {
     TEST_ENTRY(ExponentAndMantissaDecodeTests),
     TEST_ENTRY(ExponentAndMantissaDecodeFailTests),
     TEST_ENTRY(ExponentAndMantissaEncodeTests),
-    TEST_ENTRY(SpiffyIndefiniteLengthStringsTests),
 #endif /* QCBOR_CONFIG_DISABLE_EXP_AND_MANTISSA */
 };
 


### PR DESCRIPTION
Makes the smallest decoder possible smaller by 400 bytes of object code.