### PR TITLE
Makefile: Fix undefined reference problem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ all: qcbortest libqcbor.a
 so:	libqcbor.so
 
 qcbortest: libqcbor.a $(TEST_OBJ) cmd_line_main.o
-	$(CC) -o $@ $(LIBS) $^  libqcbor.a
+	$(CC) -o $@ $^ libqcbor.a $(LIBS)
 
 libqcbor.a: $(QCBOR_OBJ)
 	ar -r $@ $^


### PR DESCRIPTION
Problem is connected to the PR:
https://github.com/laurencelundblade/QCBOR/pull/60

Build still failed in the same way when using the command:
```
make -j all so
```
Putting flag at the end of the line solved the problem.

Signed-off-by: Norbert Kamiński <norbert.kaminski@3mdeb.com>