### PR TITLE
Improve encode documentation

### DIFF
--- a/example.c
+++ b/example.c
@@ -659,14 +659,14 @@ Done:
 
 int32_t RunQCborExample()
 {
-   CarEngine               E, DecodedEngine;
-   MakeUsefulBufOnStack(   EngineBuffer, 300);
-   UsefulBufC              EncodedEngine;
+   CarEngine                 E, DecodedEngine;
+   UsefulBuf_MAKE_STACK_UB(  EngineBuffer, 300);
+   UsefulBufC                EncodedEngine;
 
-   MakeUsefulBufOnStack(   InDefEngineBuffer, 300);
-   UsefulBufC              InDefEncodedEngine;
+   UsefulBuf_MAKE_STACK_UB(  InDefEngineBuffer, 300);
+   UsefulBufC                InDefEncodedEngine;
 
-   EngineDecodeErrors      uErr;
+   EngineDecodeErrors        uErr;
 
    EngineInit(&E);
 

--- a/example.c
+++ b/example.c
@@ -660,7 +660,25 @@ Done:
 int32_t RunQCborExample()
 {
    CarEngine                 E, DecodedEngine;
+
+   /* For every buffer used by QCBOR a pointer and a length are always
+    * carried in a UsefulBuf. This is a secure coding and hygene
+    * practice to help make sure code never runs off the end of a buffer.
+    *
+    * UsefulBuf structures are passed as a stack parameter to make the
+    * code prettier. The object code generated isn't much different from
+    * passing a pointer parameter and a length parameter.
+    *
+    * This macro is equivalent to:
+    *    uint8_t    __pBufEngineBuffer[300];
+    *    UsefulBuf  EngineBuffer = {__pBufEngineBuffer, 300};
+    */
    UsefulBuf_MAKE_STACK_UB(  EngineBuffer, 300);
+
+   /* The pointer in UsefulBuf is not const and used for representing
+    * a buffer to be written to. For UsefulbufC, the pointer is const
+    * and is used to represent a buffer that has been written to.
+    */
    UsefulBufC                EncodedEngine;
 
    UsefulBuf_MAKE_STACK_UB(  InDefEngineBuffer, 300);

--- a/test/qcbor_decode_tests.c
+++ b/test/qcbor_decode_tests.c
@@ -2113,7 +2113,7 @@ int32_t DecodeFailureTests()
     through the use of SIZE_MAX.
    */
 
-   MakeUsefulBufOnStack(  HeadBuf, QCBOR_HEAD_BUFFER_SIZE);
+   UsefulBuf_MAKE_STACK_UB(  HeadBuf, QCBOR_HEAD_BUFFER_SIZE);
    UsefulBufC             EncodedHead;
 
    // This makes a CBOR head with a text string that is very long
@@ -6317,7 +6317,7 @@ static UsefulBufC EncodeBstrWrapTestData(UsefulBuf OutputBuffer)
 
 int32_t EnterBstrTest()
 {
-   MakeUsefulBufOnStack(OutputBuffer, 100);
+   UsefulBuf_MAKE_STACK_UB(OutputBuffer, 100);
 
    QCBORDecodeContext DC;
 
@@ -6752,7 +6752,7 @@ int32_t SpiffyIndefiniteLengthStringsTests()
                     UsefulBuf_FROM_BYTE_ARRAY_LITERAL(spMapWithIndefLenStrings),
                     QCBOR_DECODE_MODE_NORMAL);
 
-   MakeUsefulBufOnStack(StringBuf, 200);
+   UsefulBuf_MAKE_STACK_UB(StringBuf, 200);
    QCBORDecode_SetMemPool(&DCtx, StringBuf, false);
 
    UsefulBufC ByteString;

--- a/test/qcbor_encode_tests.c
+++ b/test/qcbor_encode_tests.c
@@ -2716,7 +2716,7 @@ int32_t QCBORHeadTest()
     * other test exercises QCBOREncode_EncodeHead().
     */
    // ---- basic test to encode a zero ----
-   MakeUsefulBufOnStack(RightSize, QCBOR_HEAD_BUFFER_SIZE);
+   UsefulBuf_MAKE_STACK_UB(RightSize, QCBOR_HEAD_BUFFER_SIZE);
 
    UsefulBufC encoded = QCBOREncode_EncodeHead(RightSize,
                                                CBOR_MAJOR_TYPE_POSITIVE_INT,
@@ -2744,7 +2744,7 @@ int32_t QCBORHeadTest()
 
 
    // ---- Try to encode into too-small a buffer ----
-   MakeUsefulBufOnStack(TooSmall, QCBOR_HEAD_BUFFER_SIZE-1);
+   UsefulBuf_MAKE_STACK_UB(TooSmall, QCBOR_HEAD_BUFFER_SIZE-1);
 
    encoded = QCBOREncode_EncodeHead(TooSmall,
                                     CBOR_MAJOR_TYPE_POSITIVE_INT,


### PR DESCRIPTION
Improve the documentation for QCBOREncode_Init() and QCBOREncode_Finish().

replace all use of the deprecated macro MakeUsefulBufOnStack(). 