### PR TITLE
Make tests run correcly when SIZE_MAX is less than UINT32_MAX

### DIFF
--- a/test/not_well_formed_cbor.h
+++ b/test/not_well_formed_cbor.h
@@ -254,10 +254,10 @@ static const struct someBinaryBytes paNotWellFormedCBOR[] = {
     {(uint8_t[]){0x41}, 1},
     // A text string is of length 1 without the 1 byte
     {(uint8_t[]){0x61}, 1},
-    // Byte string should have 2^32-15 bytes, but has one
-    {(uint8_t[]){0x5a, 0xff, 0xff, 0xff, 0xf0, 0x00}, 6},
-    // Byte string should have 2^32-15 bytes, but has one
-    {(uint8_t[]){0x7a, 0xff, 0xff, 0xff, 0xf0, 0x00}, 6},
+    // Byte string should have 65520 bytes, but has one
+    {(uint8_t[]){0x59, 0xff, 0xf0, 0x00}, 6},
+    // Byte string should have 65520 bytes, but has one
+    {(uint8_t[]){0x79, 0xff, 0xf0, 0x00}, 6},
 
 
     // Use of unassigned additional information values

--- a/test/qcbor_encode_tests.c
+++ b/test/qcbor_encode_tests.c
@@ -1781,8 +1781,9 @@ int BstrWrapTest()
 int32_t BstrWrapErrorTest()
 {
    QCBOREncodeContext EC;
-   UsefulBufC Wrapped;
-   UsefulBufC Encoded2;
+   UsefulBufC         Wrapped;
+   UsefulBufC         Encoded2;
+   QCBORError         uError;
 
 #ifndef QCBOR_DISABLE_ENCODE_USAGE_GUARDS
    // ---- Test closing a bstrwrap when it is an array that is open ---------
@@ -1800,15 +1801,17 @@ int32_t BstrWrapErrorTest()
 
    QCBOREncode_CloseArray(&EC);
 
-   if(QCBOREncode_Finish(&EC, &Encoded2) != QCBOR_ERR_CLOSE_MISMATCH) {
-      return -1;
+   uError = QCBOREncode_Finish(&EC, &Encoded2);
+   if(uError != QCBOR_ERR_CLOSE_MISMATCH) {
+      return 100 + uError;
    }
 
    // -------- test closing a bstrwrap when nothing is open ----------------
    QCBOREncode_Init(&EC, UsefulBuf_FROM_BYTE_ARRAY(spBigBuf));
    QCBOREncode_CloseBstrWrap(&EC, &Wrapped);
-   if(QCBOREncode_Finish(&EC, &Encoded2) != QCBOR_ERR_TOO_MANY_CLOSES) {
-      return -2;
+   uError = QCBOREncode_Finish(&EC, &Encoded2);
+   if(uError != QCBOR_ERR_TOO_MANY_CLOSES) {
+      return 200 + uError;
    }
 #endif /* QCBOR_DISABLE_ENCODE_USAGE_GUARDS */
 
@@ -1823,8 +1826,9 @@ int32_t BstrWrapErrorTest()
       QCBOREncode_CloseBstrWrap(&EC, &Wrapped);
    }
 
-   if(QCBOREncode_Finish(&EC, &Encoded2) != QCBOR_ERR_ARRAY_NESTING_TOO_DEEP) {
-      return -3;
+   uError = QCBOREncode_Finish(&EC, &Encoded2);
+   if(uError != QCBOR_ERR_ARRAY_NESTING_TOO_DEEP) {
+      return 300 + uError;
    }
 
    return 0;


### PR DESCRIPTION
The implementation is not changed. There is no problem with it.

Only some tests didn't do their job when SIZE_MAX is less than UINT32_MAX. They should work OK now for even very small SIZE_MAX.