### PR TITLE
Allow partial decode of CBOR sequences

### DIFF
--- a/inc/qcbor/qcbor_decode.h
+++ b/inc/qcbor/qcbor_decode.h
@@ -881,12 +881,10 @@ void QCBORDecode_VGetNext(QCBORDecodeContext *pCtx, QCBORItem *pDecodedItem);
 
  This is useful for looking ahead to determine the type
  of a data item to know which type-specific spiffy decode
- function to call. 
+ function to call.
  */
 QCBORError
 QCBORDecode_PeekNext(QCBORDecodeContext *pCtx, QCBORItem *pDecodedItem);
-
-
 
 
 
@@ -1034,6 +1032,8 @@ uint64_t QCBORDecode_GetNthTagOfLast(const QCBORDecodeContext *pCtx, uint32_t uI
  input was well-formed and there are extra bytes at the end @ref
  QCBOR_ERR_EXTRA_BYTES will be returned.  This can be considered a
  successful decode.
+
+ See also QCBORDecode_PartialFinish().
  */
 QCBORError QCBORDecode_Finish(QCBORDecodeContext *pCtx);
 
@@ -1044,31 +1044,23 @@ QCBORError QCBORDecode_Finish(QCBORDecodeContext *pCtx);
  @param[in]  pCtx        The context to check.
  @param[out] puConsumed  The number of bytes consumed so far. May be @c NULL.
 
- @retval QCBOR_ERR_ARRAY_OR_MAP_STILL_OPEN The CBOR is not well-formed
-         as some map or array was not closed off. This should always
-         be treated as an unrecoverable error.
-
- @retval QCBOR_ERR_EXTRA_BYTES The CBOR was decoded correctly and all
-         maps and arrays are closed, but some of the bytes in the
-         input were not consumed.  When decoding a partial sequence
-         the caller will usually ignore this error.
-
- @retval QCBOR_SUCCES There were no errors and all bytes were
-         consumed.
+ @returns The same as QCBORDecode_Finish();
 
  This is primarily for partially decoding CBOR sequences. It is the
  same as QCBORDecode_Finish() except it returns the number of bytes
  consumed and doesn't call the destructor for the string allocator
- (See @ref and QCBORDecode_SetMemPool()). It still returns the same
- error codes so when called before all input bytes are consumed @ref
- QCBOR_ERR_EXTRA_BYTES will still be returned, but it can be ignored.
+ (See @ref and QCBORDecode_SetMemPool()).
+
+ When this is called before all input bytes are consumed, @ref
+ QCBOR_ERR_EXTRA_BYTES will be returned as QCBORDecode_Finish()
+ does. For typical use of this, that particular error is disregarded.
 
  Decoding with the same @ref QCBORDecodeContext can continue after
  calling this and this may be called many times.
 
- Another way to resume decoding is to call QCBORDecode_Init() on
- the bytes not decodied, but note that this only works on CBOR sequences
- when the decoding stopped with no open arrays, maps or byte strings.
+ Another way to resume decoding is to call QCBORDecode_Init() on the
+ bytes not decoded, but this only works on CBOR sequences when the
+ decoding stopped with no open arrays, maps or byte strings.
  */
 QCBORError
 QCBORDecode_PartialFinish(QCBORDecodeContext *pCtx, size_t *puConsumed);

--- a/inc/qcbor/qcbor_decode.h
+++ b/inc/qcbor/qcbor_decode.h
@@ -887,6 +887,9 @@ QCBORError
 QCBORDecode_PeekNext(QCBORDecodeContext *pCtx, QCBORItem *pDecodedItem);
 
 
+
+
+
 /**
  @brief Gets the next item including full list of tags for item.
 
@@ -1034,6 +1037,41 @@ uint64_t QCBORDecode_GetNthTagOfLast(const QCBORDecodeContext *pCtx, uint32_t uI
  */
 QCBORError QCBORDecode_Finish(QCBORDecodeContext *pCtx);
 
+
+/**
+ @brief Return number of bytes consumed so far.
+
+ @param[in]  pCtx        The context to check.
+ @param[out] puConsumed  The number of bytes consumed so far. May be @c NULL.
+
+ @retval QCBOR_ERR_ARRAY_OR_MAP_STILL_OPEN The CBOR is not well-formed
+         as some map or array was not closed off. This should always
+         be treated as an unrecoverable error.
+
+ @retval QCBOR_ERR_EXTRA_BYTES The CBOR was decoded correctly and all
+         maps and arrays are closed, but some of the bytes in the
+         input were not consumed.  When decoding a partial sequence
+         the caller will usually ignore this error.
+
+ @retval QCBOR_SUCCES There were no errors and all bytes were
+         consumed.
+
+ This is primarily for partially decoding CBOR sequences. It is the
+ same as QCBORDecode_Finish() except it returns the number of bytes
+ consumed and doesn't call the destructor for the string allocator
+ (See @ref and QCBORDecode_SetMemPool()). It still returns the same
+ error codes so when called before all input bytes are consumed @ref
+ QCBOR_ERR_EXTRA_BYTES will still be returned, but it can be ignored.
+
+ Decoding with the same @ref QCBORDecodeContext can continue after
+ calling this and this may be called many times.
+
+ Another way to resume decoding is to call QCBORDecode_Init() on
+ the bytes not decodied, but note that this only works on CBOR sequences
+ when the decoding stopped with no open arrays, maps or byte strings.
+ */
+QCBORError
+QCBORDecode_PartialFinish(QCBORDecodeContext *pCtx, size_t *puConsumed);
 
 
 /**

--- a/inc/qcbor/qcbor_spiffy_decode.h
+++ b/inc/qcbor/qcbor_spiffy_decode.h
@@ -151,7 +151,7 @@ extern "C" {
  example, to decode an epoch date tag the content must be an integer
  or floating-point value.
 
- If the parameter indicates it should not be a tag 
+ If the parameter indicates it should not be a tag
  (@ref  QCBOR_TAG_REQUIREMENT_NOT_A_TAG), then
   @ref QCBOR_ERR_UNEXPECTED_TYPE set if it is a tag or the type of the
  encoded CBOR is not what is expected.  In the example of an epoch

--- a/src/qcbor_decode.c
+++ b/src/qcbor_decode.c
@@ -2398,8 +2398,12 @@ bool QCBORDecode_IsTagged(QCBORDecodeContext *pMe,
 /*
  * Public function, see header qcbor/qcbor_decode.h file
  */
-QCBORError QCBORDecode_Finish(QCBORDecodeContext *pMe)
+QCBORError QCBORDecode_PartialFinish(QCBORDecodeContext *pMe, size_t *puConsumed)
 {
+   if(puConsumed != NULL) {
+      *puConsumed = pMe->InBuf.cursor;
+   }
+
    QCBORError uReturn = pMe->uLastError;
 
    if(uReturn != QCBOR_SUCCESS) {
@@ -2418,6 +2422,15 @@ QCBORError QCBORDecode_Finish(QCBORDecodeContext *pMe)
    }
 
 Done:
+   return uReturn;
+}
+
+
+/*
+ * Public function, see header qcbor/qcbor_decode.h file
+ */
+QCBORError QCBORDecode_Finish(QCBORDecodeContext *pMe)
+{
 #ifndef QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS
    /* Call the destructor for the string allocator if there is one.
     * Always called, even if there are errors; always have to clean up.
@@ -2425,7 +2438,7 @@ Done:
    StringAllocator_Destruct(&(pMe->StringAllocator));
 #endif /* QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS */
 
-   return uReturn;
+   return QCBORDecode_PartialFinish(pMe, NULL);
 }
 
 

--- a/test/qcbor_decode_tests.c
+++ b/test/qcbor_decode_tests.c
@@ -6048,8 +6048,9 @@ int32_t IntegerConvertTest()
 int32_t CBORSequenceDecodeTests(void)
 {
    QCBORDecodeContext DCtx;
-   QCBORItem Item;
-   QCBORError uCBORError;
+   QCBORItem          Item;
+   QCBORError         uCBORError;
+   size_t             uConsumed;
 
    // --- Test a sequence with extra bytes ---
 
@@ -6069,10 +6070,22 @@ int32_t CBORSequenceDecodeTests(void)
       return 2;
    }
 
+   uCBORError = QCBORDecode_PartialFinish(&DCtx, &uConsumed);
+   if(uCBORError != QCBOR_ERR_EXTRA_BYTES ||
+      uConsumed != 12) {
+      return 102;
+   }
+
    // Get a second item
    uCBORError = QCBORDecode_GetNext(&DCtx, &Item);
    if(uCBORError != QCBOR_ERR_BAD_OPT_TAG) {
       return 66;
+   }
+
+   uCBORError = QCBORDecode_PartialFinish(&DCtx, &uConsumed);
+   if(uCBORError != QCBOR_ERR_EXTRA_BYTES ||
+      uConsumed != 14) {
+      return 102;
    }
 
    // Get a third item

--- a/test/qcbor_decode_tests.c
+++ b/test/qcbor_decode_tests.c
@@ -1771,7 +1771,7 @@ static int32_t ProcessFailures(const struct FailInput *pFailInputs, size_t nNumF
       }
 #endif /* QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS */
 
-      
+
       // Iterate until there is an error of some sort error
       QCBORItem Item;
       do {


### PR DESCRIPTION
Adds QCBORDecode_PartialFinish() method for use on sequences without having to consume the whole sequence.

This is to resolve #76 
