### PR TITLE
added test case of having an Empty Map as a Map Value

### DIFF
--- a/test/qcbor_decode_tests.c
+++ b/test/qcbor_decode_tests.c
@@ -919,6 +919,33 @@ int32_t EmptyMapsAndArraysTest()
 }
 
 /* [[[[[[[[[[]]]]]]]]]] */
+static uint8_t sEmptyMap[] = {
+                              0xA1,     //# map(1)
+                              0x02,     //# unsigned(2)
+                              0xA0,     //# map(0)
+};
+
+int32_t ParseEmptyMapInMapTest(void)
+{
+   QCBORDecodeContext DCtx;
+   QCBORItem Item;
+   int nReturn = 0;
+
+   QCBORDecode_Init(&DCtx,
+                    UsefulBuf_FROM_BYTE_ARRAY_LITERAL(sEmptyMap),
+                    QCBOR_DECODE_MODE_NORMAL);
+
+   if(QCBORDecode_GetNext(&DCtx, &Item) != 0 ||
+      Item.uDataType != QCBOR_TYPE_ARRAY ||
+      Item.uNestingLevel != 1 ||
+      Item.label.int64 != 2) {
+     nReturn = -1;
+   }
+
+   return(nReturn);
+}
+
+/* [[[[[[[[[[]]]]]]]]]] */
 static const uint8_t spDeepArrays[] = {
    0x81, 0x81, 0x81, 0x81, 0x81, 0x81, 0x81, 0x81,
    0x81, 0x80};

--- a/test/qcbor_decode_tests.c
+++ b/test/qcbor_decode_tests.c
@@ -935,13 +935,26 @@ int32_t ParseEmptyMapInMapTest(void)
                     UsefulBuf_FROM_BYTE_ARRAY_LITERAL(sEmptyMap),
                     QCBOR_DECODE_MODE_NORMAL);
 
-   if(QCBORDecode_GetNext(&DCtx, &Item) != 0 ||
-      Item.uDataType != QCBOR_TYPE_ARRAY ||
+   /* now open the first Map */
+   nReturn = QCBORDecode_GetNext(&DCtx, &Item);
+    if(nReturn != QCBOR_SUCCESS ||
+       Item.uDataType != QCBOR_TYPE_MAP) {
+      nReturn = -3;
+      goto done;
+    }
+
+   if(QCBORDecode_GetNext(&DCtx, &Item) != 0) {
+     nReturn = -1;
+     goto done;
+   }
+   if(Item.uDataType != QCBOR_TYPE_MAP ||
       Item.uNestingLevel != 1 ||
       Item.label.int64 != 2) {
-     nReturn = -1;
+     nReturn = -2;
+     goto done;
    }
 
+ done:
    return(nReturn);
 }
 

--- a/test/qcbor_decode_tests.h
+++ b/test/qcbor_decode_tests.h
@@ -112,6 +112,10 @@ int32_t ShortBufferParseTest2(void);
  */
 int32_t ParseMapTest(void);
 
+/*
+  Parses a map that contains a zero-length map as value.
+*/
+int32_t ParseEmptyMapInMapTest(void);
 
 /*
 Test the decoder mode where maps are treated as arrays.

--- a/test/run_tests.c
+++ b/test/run_tests.c
@@ -130,6 +130,7 @@ static test_entry s_tests[] = {
     TEST_ENTRY(ExponentAndMantissaDecodeFailTests),
     TEST_ENTRY(ExponentAndMantissaEncodeTests),
 #endif /* QCBOR_CONFIG_DISABLE_EXP_AND_MANTISSA */
+    TEST_ENTRY(ParseEmptyMapInMapTest),
 };
 
 


### PR DESCRIPTION
this adds a test case of a map with a single item failing to decode with the label.
