### PR TITLE
Quiet warnings for stricter compilers configurations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,27 @@
 # Makefile -- UNIX-style make for qcbor as a lib and command line test
 #
-# Copyright (c) 2018-2020, Laurence Lundblade. All rights reserved.
+# Copyright (c) 2018-2021, Laurence Lundblade. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
 # See BSD-3-Clause license in README.md
 #
 
-CC=cc
-#CC=/usr/local/bin/gcc-9
 
+# The math library is needed for floating-point support. To
+# avoid need for it #define QCBOR_DISABLE_FLOAT_HW_USE
 LIBS=-lm
-CFLAGS=$(CMD_LINE) -I inc -I test -Os -fPIC 
 
-# The following are used before a release of QCBOR help to make sure
-# the code compiles and runs in the most strict environments, but not
-# all compilers support them so they are not turned on.
-#CFLAGS=-I inc -I test -Os -fpic -Wall -pedantic-errors -Wextra -Wshadow -Wparentheses -Wconversion -xc -std=c99
+
+# The QCBOR makefile uses a minimum of compiler flags so that it will
+# work out-of-the-box with a wide variety of compilers.  For example,
+# some compiler error out on some of the warnings flags available with
+# gcc. The $(CMD_LINE) variable allows passing in extra flags. This is
+# used on the stringent build script that is in
+# https://github.com/laurencelundblade/qdv.  This script is used
+# before pushes to master (though not yet through and automated build
+# process)
+CFLAGS=$(CMD_LINE) -I inc -I test -Os -fPIC
 
 
 QCBOR_OBJ=src/UsefulBuf.o src/qcbor_encode.o src/qcbor_decode.o src/ieee754.o src/qcbor_err_to_str.o
@@ -36,6 +41,7 @@ qcbortest: libqcbor.a $(TEST_OBJ) cmd_line_main.o
 
 libqcbor.a: $(QCBOR_OBJ)
 	ar -r $@ $^
+
 
 # The shared library is not made by default because of platform
 # variability For example MacOS and Linux behave differently and some

--- a/inc/qcbor/UsefulBuf.h
+++ b/inc/qcbor/UsefulBuf.h
@@ -379,10 +379,10 @@ static inline UsefulBufC UsefulBuf_Const(const UsefulBuf UB);
 
  @return A non-const @ref UsefulBuf struct.
 
- It is better to avoid use of this. The intended convention for UsefulBuf is to make an empty
- buffer, some memory, as a UsefulBuf, fill it in, and then
- make it a UsefulBufC. In that convension this function is
- not needed.
+ It is better to avoid use of this. The intended convention for
+ UsefulBuf is to make an empty buffer, some memory, as a UsefulBuf,
+ fill it in, and then make it a UsefulBufC. In that convension this
+ function is not needed.
 
  This is an explicit way to quiet compiler warnings from
  -Wcast-qual.

--- a/inc/qcbor/UsefulBuf.h
+++ b/inc/qcbor/UsefulBuf.h
@@ -41,6 +41,7 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
  when         who             what, where, why
  --------     ----            --------------------------------------------------
+ 3/6/2021     mcr/llundblade  Fix warnings related to --Wcast-qual
  2/17/2021    llundblade      Add method to go from a pointer to an offset.
  1/25/2020    llundblade      Add some casts so static anlyzers don't complain.
  5/21/2019    llundblade      #define configs for efficient endianness handling.
@@ -377,6 +378,14 @@ static inline UsefulBufC UsefulBuf_Const(const UsefulBuf UB);
  @param[in] UBC The @ref UsefulBuf to convert.
 
  @return A non-const @ref UsefulBuf struct.
+
+ It is better to avoid use of this. The intended convention for UsefulBuf is to make an empty
+ buffer, some memory, as a UsefulBuf, fill it in, and then
+ make it a UsefulBufC. In that convension this function is
+ not needed.
+
+ This is an explicit way to quiet compiler warnings from
+ -Wcast-qual.
  */
 static inline UsefulBuf UsefulBuf_Unconst(const UsefulBufC UBC);
 
@@ -606,7 +615,7 @@ size_t UsefulBuf_FindBytes(UsefulBufC BytesToSearch, UsefulBufC BytesToFind);
 static inline size_t UsefulBuf_PointerToOffset(UsefulBufC UB, const void *p);
 
 
-#if 1 // NOT_DEPRECATED
+#ifndef USEFULBUF_DISABLE_DEPRECATED
 /** Deprecated macro; use @ref UsefulBuf_FROM_SZ_LITERAL instead */
 #define SZLiteralToUsefulBufC(szString) \
     ((UsefulBufC) {(szString), sizeof(szString)-1})
@@ -623,9 +632,13 @@ static inline size_t UsefulBuf_PointerToOffset(UsefulBufC UB, const void *p);
 /** Deprecated function; use UsefulBuf_Unconst() instead */
 static inline UsefulBuf UsefulBufC_Unconst(const UsefulBufC UBC)
 {
+   // See UsefulBuf_Unconst() implementation for comment on pragmas
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
     return (UsefulBuf){(void *)UBC.ptr, UBC.len};
+#pragma GCC diagnostic pop
 }
-#endif
+#endif /* USEFULBUF_DISABLE_DEPRECATED */
 
 
 
@@ -1597,10 +1610,15 @@ static inline UsefulBufC UsefulBuf_Const(const UsefulBuf UB)
    return (UsefulBufC){UB.ptr, UB.len};
 }
 
-
 static inline UsefulBuf UsefulBuf_Unconst(const UsefulBufC UBC)
 {
+   /* -Wcast-qual is a good warning flag to use in general. This is
+    * the one place in UsefulBuf where it needs to be quieted. Since
+    * clang supports GCC pragmas, this works for clang too. */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
    return (UsefulBuf){(void *)UBC.ptr, UBC.len};
+#pragma GCC diagnostic pop
 }
 
 
@@ -1647,7 +1665,7 @@ static inline UsefulBufC UsefulBuf_Tail(UsefulBufC UB, size_t uAmount)
    } else if(UB.ptr == NULL) {
       ReturnValue = (UsefulBufC){NULL, UB.len - uAmount};
    } else {
-      ReturnValue = (UsefulBufC){(uint8_t *)UB.ptr + uAmount, UB.len - uAmount};
+      ReturnValue = (UsefulBufC){(const uint8_t *)UB.ptr + uAmount, UB.len - uAmount};
    }
 
    return ReturnValue;
@@ -1666,7 +1684,7 @@ static inline size_t UsefulBuf_PointerToOffset(UsefulBufC UB, const void *p)
    }
 
    // Cast to size_t (from ptrdiff_t) is OK because of check above
-   const size_t uOffset = (size_t)((uint8_t *)p - (uint8_t *)UB.ptr);
+   const size_t uOffset = (size_t)((const uint8_t *)p - (const uint8_t *)UB.ptr);
 
     if(uOffset >= UB.len) {
       /* given pointer is off the end of the buffer */
@@ -2067,7 +2085,7 @@ static inline uint8_t UsefulInputBuf_GetByte(UsefulInputBuf *pMe)
    // The ternery operator is subject to integer promotion, because the
    // operands are smaller than int, so cast back to uint8_t is needed
    // to be completely explicit about types (for static analyzers)
-   return (uint8_t)(pResult ? *(uint8_t *)pResult : 0);
+   return (uint8_t)(pResult ? *(const uint8_t *)pResult : 0);
 }
 
 static inline uint16_t UsefulInputBuf_GetUint16(UsefulInputBuf *pMe)

--- a/inc/qcbor/qcbor_encode.h
+++ b/inc/qcbor/qcbor_encode.h
@@ -1,6 +1,6 @@
 /*==============================================================================
  Copyright (c) 2016-2018, The Linux Foundation.
- Copyright (c) 2018-2020, Laurence Lundblade.
+ Copyright (c) 2018-2021, Laurence Lundblade.
  All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/inc/qcbor/qcbor_encode.h
+++ b/inc/qcbor/qcbor_encode.h
@@ -1722,6 +1722,8 @@ static void QCBOREncode_AddEncodedToMapN(QCBOREncodeContext *pCtx, int64_t nLabe
  @param[out] pEncodedCBOR  Structure in which the pointer and length of the encoded
                            CBOR is returned.
 
+ @retval QCBOR_SUCCESS                     Encoded CBOR is returned.
+
  @retval QCBOR_ERR_TOO_MANY_CLOSES         Nesting error
 
  @retval QCBOR_ERR_CLOSE_MISMATCH          Nesting error

--- a/src/UsefulBuf.c
+++ b/src/UsefulBuf.c
@@ -1,6 +1,6 @@
 /*==============================================================================
  Copyright (c) 2016-2018, The Linux Foundation.
- Copyright (c) 2018-2020, Laurence Lundblade.
+ Copyright (c) 2018-2021, Laurence Lundblade.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -41,6 +41,7 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
  when        who          what, where, why
  --------    ----         ---------------------------------------------------
+ 3/6/2021     mcr/llundblade  Fix warnings related to --Wcast-qual
  01/28/2020  llundblade   Refine integer signedness to quiet static analysis.
  01/08/2020  llundblade   Documentation corrections & improved code formatting.
  11/08/2019  llundblade   Re check pointer math and update comments
@@ -106,12 +107,12 @@ size_t UsefulBuf_IsValue(const UsefulBufC UB, uint8_t uValue)
       return 0;
    }
 
-   const uint8_t * const pEnd = (uint8_t *)UB.ptr + UB.len;
+   const uint8_t * const pEnd = (const uint8_t *)UB.ptr + UB.len;
    for(const uint8_t *p = UB.ptr; p < pEnd; p++) {
       if(*p != uValue) {
          /* Byte didn't match */
          /* Cast from signed  to unsigned . Safe because the loop increments.*/
-         return (size_t)(p - (uint8_t *)UB.ptr);
+         return (size_t)(p - (const uint8_t *)UB.ptr);
       }
    }
 
@@ -130,7 +131,7 @@ size_t UsefulBuf_FindBytes(UsefulBufC BytesToSearch, UsefulBufC BytesToFind)
    }
 
    for(size_t uPos = 0; uPos <= BytesToSearch.len - BytesToFind.len; uPos++) {
-      if(!UsefulBuf_Compare((UsefulBufC){((uint8_t *)BytesToSearch.ptr) + uPos, BytesToFind.len}, BytesToFind)) {
+      if(!UsefulBuf_Compare((UsefulBufC){((const uint8_t *)BytesToSearch.ptr) + uPos, BytesToFind.len}, BytesToFind)) {
          return uPos;
       }
    }
@@ -358,7 +359,7 @@ const void * UsefulInputBuf_GetBytes(UsefulInputBuf *pMe, size_t uAmount)
    }
 
    // This is going to succeed
-   const void * const result = ((uint8_t *)pMe->UB.ptr) + pMe->cursor;
+   const void * const result = ((const uint8_t *)pMe->UB.ptr) + pMe->cursor;
    // Will not overflow because of check using UsefulInputBuf_BytesAvailable()
    pMe->cursor += uAmount;
    return result;

--- a/test/UsefulBuf_Tests.c
+++ b/test/UsefulBuf_Tests.c
@@ -41,7 +41,7 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
    There is nothing adversarial in this test
  */
-const char * UOBTest_NonAdversarial()
+const char * UOBTest_NonAdversarial(void)
 {
    const char *szReturn = NULL;
 
@@ -160,7 +160,7 @@ static int InsertTest(UsefulOutBuf *pUOB,  size_t num, size_t pos, int expected)
 
  */
 
-const char *UOBTest_BoundaryConditionsTest()
+const char *UOBTest_BoundaryConditionsTest(void)
 {
    UsefulBuf_MAKE_STACK_UB(outbuf,2);
 
@@ -248,7 +248,7 @@ const char *UOBTest_BoundaryConditionsTest()
 
 // Test function to get size and magic number check
 
-const char *TestBasicSanity()
+const char *TestBasicSanity(void)
 {
    UsefulBuf_MAKE_STACK_UB(outbuf,10);
 
@@ -293,7 +293,7 @@ const char *TestBasicSanity()
 
 
 
-const char *UBMacroConversionsTest()
+const char *UBMacroConversionsTest(void)
 {
    char *szFoo = "foo";
 
@@ -310,16 +310,17 @@ const char *UBMacroConversionsTest()
    if(Boo.len != 3 || strncmp(Boo.ptr, "Boo", 3))
      return "UsefulBuf_FROM_BYTE_ARRAY_LITERAL failed";
 
-   UsefulBuf B = (UsefulBuf){(void *)Too.ptr, Too.len};
+   char *String = "string"; // Intentionally not const
+   UsefulBuf B = (UsefulBuf){(void *)String, strlen(String)};
    UsefulBufC BC = UsefulBuf_Const(B);
-   if(BC.len != Too.len || BC.ptr != Too.ptr)
+   if(BC.len != strlen(String) || BC.ptr != String)
       return "UsefulBufConst failed";
 
    return NULL;
 }
 
 
-const char *UBUtilTests()
+const char *UBUtilTests(void)
 {
    UsefulBuf UB = NULLUsefulBuf;
 
@@ -628,7 +629,7 @@ const char *UBUtilTests()
 }
 
 
-const char *  UIBTest_IntegerFormat()
+const char *  UIBTest_IntegerFormat(void)
 {
    UsefulOutBuf_MakeOnStack(UOB, 100);
 
@@ -736,7 +737,7 @@ const char *  UIBTest_IntegerFormat()
 }
 
 
-const char *UBUTest_CopyUtil()
+const char *UBUTest_CopyUtil(void)
 {
    if(UsefulBufUtil_CopyFloatToUint32(65536.0F) != 0x47800000) {
       return "CopyFloatToUint32 failed";

--- a/test/qcbor_decode_tests.c
+++ b/test/qcbor_decode_tests.c
@@ -5043,7 +5043,7 @@ static int32_t DecodeNestedGetZero(QCBORDecodeContext *pDCtx)
 
 /* Repeatedly enter and exit maps and arrays, go off the end of maps
  and arrays and such. */
-static int32_t DecodeNestedIterate()
+static int32_t DecodeNestedIterate(void)
 {
    QCBORDecodeContext DCtx;
    int32_t            nReturn;

--- a/test/qcbor_encode_tests.c
+++ b/test/qcbor_encode_tests.c
@@ -116,10 +116,10 @@ UsefulBuf_CompareWithDiagnostic(UsefulBufC Actual,
                                 struct UBCompareDiagnostic *pDiag) {
    size_t i;
    for(i = 0; i < Actual.len; i++) {
-      if(((uint8_t *)Actual.ptr)[i] != ((uint8_t *)Expected.ptr)[i]) {
+      if(((const uint8_t *)Actual.ptr)[i] != ((const uint8_t *)Expected.ptr)[i]) {
          if(pDiag) {
-            pDiag->uActual   = ((uint8_t *)Actual.ptr)[i];
-            pDiag->uExpected = ((uint8_t *)Expected.ptr)[i];
+            pDiag->uActual   = ((const uint8_t *)Actual.ptr)[i];
+            pDiag->uExpected = ((const uint8_t *)Expected.ptr)[i];
             pDiag->uOffset   = i;
          }
          // Cast to int is OK as this is only a diagnostic and the sizes


### PR DESCRIPTION
Fix warnings from -Wcast-qual and -Wstrict-prototypes.

A few other warning fixes and documentation improvements are added.

Also fixes Makefile so the before-release build script can invoke both gcc and clang. That script is here: https://github.com/laurencelundblade/qdv/commit/536f0834fc2f84c17ea0b63513e596cfca1ff9f7

This is an alternative to #79.  It does not fix warnings for -Wbad-function-cast
 because those fixes cause warnings with other compilers (MacOS clang). This doesn't enable GitHub automated build checks. The plan is to do that separately. 