### PR TITLE
Add explicit casts to satisfy g++

### DIFF
--- a/inc/qcbor/qcbor_decode.h
+++ b/inc/qcbor/qcbor_decode.h
@@ -1281,12 +1281,12 @@ static inline int QCBOR_Int64ToUInt64(int64_t src, uint64_t *dest)
 
 static inline QCBORError QCBORDecode_GetError(QCBORDecodeContext *pMe)
 {
-    return pMe->uLastError;
+    return (QCBORError)pMe->uLastError;
 }
 
 static inline QCBORError QCBORDecode_GetAndResetError(QCBORDecodeContext *pMe)
 {
-    const QCBORError uReturn = pMe->uLastError;
+    const QCBORError uReturn = (QCBORError)pMe->uLastError;
     pMe->uLastError = QCBOR_SUCCESS;
     return uReturn;
 }


### PR DESCRIPTION
g++ version 10.2 refuses to compile any C++ file that includes qcbor_decode.h:

```
inc/qcbor/qcbor_decode.h: In function ‘QCBORError QCBORDecode_GetError(QCBORDecodeContext*)’:
inc/qcbor/qcbor_decode.h:1284:17: error: invalid conversion from ‘uint8_t’ {aka ‘unsigned char’} to ‘QCBORError’ [-fpermissive]
 1284 |     return pMe->uLastError;
      |            ~~~~~^~~~~~~~~~
      |                 |
      |                 uint8_t {aka unsigned char}
```

I've added explicit casts to fix the error.