### PR TITLE
Fix gcc compiler warning in QCBORDecode_VGetNextConsume

### DIFF
--- a/src/qcbor_decode.c
+++ b/src/qcbor_decode.c
@@ -2680,7 +2680,7 @@ static inline void CopyTags(QCBORDecodeContext *pMe, const QCBORItem *pItem)
 static inline QCBORError
 ConsumeItem(QCBORDecodeContext *pMe,
             const QCBORItem    *pItemToConsume,
-            uint_fast8_t       *puNextNestLevel)
+            uint8_t            *puNextNestLevel)
 {
    QCBORError uReturn;
    QCBORItem  Item;
@@ -2923,7 +2923,7 @@ MapSearch(QCBORDecodeContext *pMe,
     that error code is returned.
     */
    const uint8_t uMapNestLevel = DecodeNesting_GetBoundedModeLevel(&(pMe->nesting));
-   uint_fast8_t  uNextNestLevel;
+   uint8_t       uNextNestLevel;
    do {
       /* Remember offset of the item because sometimes it has to be returned */
       const size_t uOffset = UsefulInputBuf_Tell(&(pMe->InBuf));


### PR DESCRIPTION
This fixes an 'incompatible pointer type' warning in QCBORDecode_VGetNextConsume:
```
src/qcbor_decode.c: In function 'QCBORDecode_VGetNextConsume':
src/qcbor_decode.c:2728:65: warning: passing argument 3 of 'ConsumeItem' from incompatible pointer type [-Wincompatible-pointer-types]
 2728 |       pMe->uLastError = (uint8_t)ConsumeItem(pMe, pDecodedItem, &uNextNestLevel);
      |                                                                 ^~~~~~~~~~~~~~~
      |                                                                 |
      |                                                                 uint8_t * {aka unsigned char *}
src/qcbor_decode.c:2683:33: note: expected 'uint_fast8_t *' {aka 'unsigned int *'} but argument is of type 'uint8_t *' {aka 'unsigned char *'}
 2683 |             uint_fast8_t       *puNextNestLevel)
      |             ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
```

Found with gcc-arm-9.2-2019.12-x86_64-aarch64-none-elf compiler. 

Fix tested in WSL, Ubuntu 18.04: All 71 tests passes.

