### PR TITLE
Fix another gcc compiler warning in QCBORDecode_VGetNextConsume

### DIFF
--- a/src/qcbor_decode.c
+++ b/src/qcbor_decode.c
@@ -2767,13 +2767,11 @@ Done:
 
 void QCBORDecode_VGetNextConsume(QCBORDecodeContext *pMe, QCBORItem *pDecodedItem)
 {
-   uint8_t    uNextNestLevel;
-
    QCBORDecode_VGetNext(pMe, pDecodedItem);
 
    if(pMe->uLastError == QCBOR_SUCCESS) {
-      pMe->uLastError = (uint8_t)ConsumeItem(pMe, pDecodedItem, &uNextNestLevel);
-      pDecodedItem->uNextNestLevel = uNextNestLevel;
+      pMe->uLastError = (uint8_t)ConsumeItem(pMe, pDecodedItem,
+         &pDecodedItem->uNextNestLevel);
    }
 }
 


### PR DESCRIPTION
This fixes a "possible uninitialise variable" warning. I think I missed it last time, because it appeared when I was using O2 optimisation. Found with gcc-arm-9.2-2019.12-x86_64-aarch64-none-elf compiler.

```
gcc -DQCBOR_DISABLE_FLOAT_HW_USE -DQCBOR_DISABLE_PREFERRED_FLOAT -O2 -Wall -I inc -I test -O2 -fPIC   -c -o src/qcbor_decode.o src/qcbor_decode.c
src/qcbor_decode.c: In function 'QCBORDecode_VGetNextConsume':
src/qcbor_decode.c:2776:36: warning: 'uNextNestLevel' may be used uninitialized in this function [-Wmaybe-uninitialized]
 2776 |       pDecodedItem->uNextNestLevel = uNextNestLevel;
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
```

The reason for this seems to be that the compiler detects (as inlining is used at this optimisation level) that if an error happens in the loop in `ConsumeItem`, then the `*puNextNestLevel` is not set. 

Now this should not be a problem if the library is used properly, because `uLastError` is set in the context, and the uninitialized value is not used. However having a warning might be a problem for projects using strict warning policy.

The fix I present in the PR is quite trivial, however it migth have effect on code size (not sure how sensitive is this). 

It would be possible to pass the parameter of QCBORDecode_VGetNextConsume to ConsumeItem directly like this:

```
void QCBORDecode_VGetNextConsume(QCBORDecodeContext *pMe, QCBORItem *pDecodedItem)
{
   QCBORDecode_VGetNext(pMe, pDecodedItem);

   if(pMe->uLastError == QCBOR_SUCCESS) {
      pMe->uLastError = (uint8_t)ConsumeItem(pMe, pDecodedItem, 
      	&pDecodedItem->uNextNestLevel);
   }
}
```

This is not that pretty, but has positive effect on the codesize (with this particular compiler, the numbers are the size of the .text section of qcbor_decode.o):

```
+-----+---------+-------------+----------------+
|     | master  | fix in PR   |no temp variable|
+=====+=========+=============+================+
| -O0 | 0x6f64  | 0x6f68      |0x6f5c          |
+-----+---------+-------------+----------------+
| -O1 | 0x4660  | 0x4668      |0x4668          |
+-----+---------+-------------+----------------+
| -O2 | 0x485c  | 0x4854      |0x4854          |
+-----+---------+-------------+----------------+
| -O3 | 0x7258  | 0x7250      |0x7250          |
+-----+---------+-------------+----------------+
| -Os | 0x3b90  | 0x3b94      |0x3b88          |
+-----+---------+-------------+----------------+
```

Fix tested in WSL, Ubuntu 18.04: All 71 tests passes.