### PR TITLE
Add QCBOREncode_CancelBstrWrap()

### DIFF
--- a/inc/qcbor/qcbor_common.h
+++ b/inc/qcbor/qcbor_common.h
@@ -502,6 +502,10 @@ typedef enum {
        indefinite length map or array in the input CBOR. */
    QCBOR_ERR_INDEF_LEN_ARRAYS_DISABLED = 44,
 
+   /** Trying to cancel a byte string wrapping after items have been
+       added to it. */
+   QCBOR_ERR_CANNOT_CANCEL = 45,
+
    /* This is stored in uint8_t; never add values > 255 */
 } QCBORError;
 

--- a/inc/qcbor/qcbor_encode.h
+++ b/inc/qcbor/qcbor_encode.h
@@ -1774,6 +1774,17 @@ static void QCBOREncode_CloseBstrWrap(QCBOREncodeContext *pCtx, UsefulBufC *pWra
 
 
 /**
+ @brief Cancel a wrapping bstr.
+
+ @param[in] pCtx              The encoding context to close of bstr wrapping in.
+
+ This only works if nothing has been added into the wrapped byte string.
+ If something has been added, this sets the TODO: error.
+ **/
+void QCBOREncode_CancelBstrWrap(QCBOREncodeContext *pCtx);
+
+
+/**
  @brief Add some already-encoded CBOR bytes.
 
  @param[in] pCtx     The encoding context to add the already-encode CBOR to.

--- a/inc/qcbor/qcbor_encode.h
+++ b/inc/qcbor/qcbor_encode.h
@@ -1776,14 +1776,14 @@ static void QCBOREncode_CloseBstrWrap(QCBOREncodeContext *pCtx, UsefulBufC *pWra
 /**
  * @brief Cancel byte string wrapping.
  *
- * @param[in] pCtx       The encoding context to close of bstr wrapping in.
+ * @param[in] pCtx       The encoding context.
  *
  * This cancels QCBOREncode_BstrWrap() making tghe encoding as if it
  * were never called.
  *
- * WARNING: This does no work on QCBOREncode_BstrWrapInMap()
- * or QCBOREncode_BstrWrapInMapN() and there is no detection
- * of this error.
+ * WARNING: This does not work on QCBOREncode_BstrWrapInMap()
+ * or QCBOREncode_BstrWrapInMapN() and there is no error detection
+ * of an attempt at their use.
  *
  * This only works if nothing has been added into the wrapped byte
  * string.  If something has been added, this sets the error

--- a/inc/qcbor/qcbor_encode.h
+++ b/inc/qcbor/qcbor_encode.h
@@ -1774,13 +1774,21 @@ static void QCBOREncode_CloseBstrWrap(QCBOREncodeContext *pCtx, UsefulBufC *pWra
 
 
 /**
- @brief Cancel a wrapping bstr.
-
- @param[in] pCtx              The encoding context to close of bstr wrapping in.
-
- This only works if nothing has been added into the wrapped byte string.
- If something has been added, this sets the TODO: error.
- **/
+ * @brief Cancel byte string wrapping.
+ *
+ * @param[in] pCtx       The encoding context to close of bstr wrapping in.
+ *
+ * This cancels QCBOREncode_BstrWrap() making tghe encoding as if it
+ * were never called.
+ *
+ * WARNING: This does no work on QCBOREncode_BstrWrapInMap()
+ * or QCBOREncode_BstrWrapInMapN() and there is no detection
+ * of this error.
+ *
+ * This only works if nothing has been added into the wrapped byte
+ * string.  If something has been added, this sets the error
+ * @ref QCBOR_ERR_CANNOT_CANCEL.
+ */
 void QCBOREncode_CancelBstrWrap(QCBOREncodeContext *pCtx);
 
 

--- a/src/qcbor_encode.c
+++ b/src/qcbor_encode.c
@@ -918,6 +918,14 @@ void QCBOREncode_CancelBstrWrap(QCBOREncodeContext *pMe)
          return;
       }
    }
+   /* QCBOREncode_CancelBstrWrap() can't correctly undo
+    * QCBOREncode_BstrWrapInMap() or QCBOREncode_BstrWrapInMapN(). It
+    * can't undo the labels they add. It also doesn't catch the error
+    * of using it this way.  QCBOREncode_CancelBstrWrap() is used
+    * infrequently and the the result is incorrect CBOR, not a
+    * security hole, so no extra code or state is added to handle this
+    * condition.
+    */
 #endif /* QCBOR_DISABLE_ENCODE_USAGE_GUARDS */
 
    Nesting_Decrease(&(pMe->nesting));

--- a/src/qcbor_encode.c
+++ b/src/qcbor_encode.c
@@ -114,17 +114,12 @@ inline static uint8_t Nesting_Increment(QCBORTrackNesting *pNesting)
    return QCBOR_SUCCESS;
 }
 
-inline static uint8_t Nesting_Decrement(QCBORTrackNesting *pNesting)
+inline static void Nesting_Decrement(QCBORTrackNesting *pNesting)
 {
-#ifndef QCBOR_DISABLE_ENCODE_USAGE_GUARDS
-   if(!pNesting->pCurrentNesting->uCount) {
-      return 99; // TODO: error
-   }
-#endif /* QCBOR_DISABLE_ENCODE_USAGE_GUARDS */
-
+   /* No error check for going below 0 here needed because this
+    * is only used by QCBOREncode_CancelBstrWrap() and it checks
+    * the nesting level before calling this. */
    pNesting->pCurrentNesting->uCount--;
-
-   return QCBOR_SUCCESS;
 }
 
 inline static uint16_t Nesting_GetCount(QCBORTrackNesting *pNesting)

--- a/test/qcbor_encode_tests.c
+++ b/test/qcbor_encode_tests.c
@@ -1745,7 +1745,7 @@ static const uint8_t spExpectedBstrWrap[] = {0x82, 0x19, 0x01, 0xC3, 0x43, 0x19,
  */
 static const uint8_t spExpectedTypeAndLen[] = {0x81, 0x58, 0x25};
 
-static const uint8_t spExpectedTypeAndLenXXX[] = {0x82, 0x19, 0x01, 0xC3, 0x18, 0x2A};
+static const uint8_t spExpectedForBstrWrapCancel[] = {0x82, 0x19, 0x01, 0xC3, 0x18, 0x2A};
 
 /*
  * bstr wrapping test
@@ -1823,7 +1823,7 @@ int BstrWrapTest()
    if(QCBOREncode_Finish(&EC, &Encoded)) {
       return -8;
    }
-   if(CheckResults(Encoded, spExpectedTypeAndLenXXX)) {
+   if(CheckResults(Encoded, spExpectedForBstrWrapCancel)) {
       return -9;
    }
 
@@ -1845,7 +1845,7 @@ int BstrWrapTest()
    if(uErr != QCBOR_ERR_CANNOT_CANCEL) {
       return -10;
    }
-#endif
+#endif /* QCBOR_DISABLE_ENCODE_USAGE_GUARDS */
 
    // Sixth test, another cancel, but the error is not caught
    // This use will produce unintended CBOR. The error

--- a/test/qcbor_encode_tests.c
+++ b/test/qcbor_encode_tests.c
@@ -1745,6 +1745,7 @@ static const uint8_t spExpectedBstrWrap[] = {0x82, 0x19, 0x01, 0xC3, 0x43, 0x19,
  */
 static const uint8_t spExpectedTypeAndLen[] = {0x81, 0x58, 0x25};
 
+static const uint8_t spExpectedTypeAndLenXXX[] = {0x82, 0x19, 0x01, 0xC3, 0x18, 0x2A};
 /*
  Very basic bstr wrapping test
  */
@@ -1804,6 +1805,43 @@ int BstrWrapTest()
    }
    if(CheckResults(Encoded, spExpectedTypeAndLen)) {
       return -7;
+   }
+
+
+   // Fourth test, cancelling a byte string
+   QCBOREncode_Init(&EC, UsefulBuf_FROM_BYTE_ARRAY(spBigBuf));
+
+   QCBOREncode_OpenArray(&EC);
+   QCBOREncode_AddUInt64(&EC, 451);
+
+   QCBOREncode_BstrWrap(&EC);
+   QCBOREncode_CancelBstrWrap(&EC);
+
+
+   QCBOREncode_AddUInt64(&EC, 42);
+   QCBOREncode_CloseArray(&EC);
+   if(QCBOREncode_Finish(&EC, &Encoded)) {
+      return -8;
+   }
+   if(CheckResults(Encoded, spExpectedTypeAndLenXXX)) {
+      return -9;
+   }
+
+   // Fifth test, failed cancelling
+   QCBOREncode_Init(&EC, UsefulBuf_FROM_BYTE_ARRAY(spBigBuf));
+
+   QCBOREncode_OpenArray(&EC);
+   QCBOREncode_AddUInt64(&EC, 451);
+
+   QCBOREncode_BstrWrap(&EC);
+   QCBOREncode_AddUInt64(&EC, 99);
+   QCBOREncode_CancelBstrWrap(&EC);
+
+   QCBOREncode_AddUInt64(&EC, 42);
+   QCBOREncode_CloseArray(&EC);
+   QCBORError uErr = QCBOREncode_Finish(&EC, &Encoded);
+   if(uErr != QCBOR_ERR_CANNOT_CANCEL) {
+      return -10;
    }
 
    return 0;


### PR DESCRIPTION
If nothing has been added to a BstrWrap this can cancel it so it is like it was never called.