### PR TITLE
Simplify error codes and tests when disabling floats (minor interface incompatibility)

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,8 +479,9 @@ still exist and work the same)
 * Michael Eckel for Makefile improvements
 * Jan Jongboom for indefinite length encoding
 * Peter Uiterwijk for error strings and other
-* Michael Richarson for CI set up and additional compiler warnings
-
+* Michael Richarson for CI set up and fixing some compiler warnings
+* Máté Tóth-Pál for float-point disabling and other
+* Dave Thaler for portability to Windows
 
 ## Copyright and License
 

--- a/inc/qcbor/qcbor_common.h
+++ b/inc/qcbor/qcbor_common.h
@@ -488,8 +488,11 @@ typedef enum {
        non-CBOR reason */
    QCBOR_ERR_CALLBACK_FAIL = 38,
 
-   /** Decoding of floating-point epoch dates is unsupported and a
-       floating-point date was encountered by the decoder. */
+   /** This error code is deprecated. Instead, 
+       \ref QCBOR_ERR_HALF_PRECISION_DISABLED,
+       \ref QCBOR_ERR_HW_FLOAT_DISABLED or \ref QCBOR_ERR_ALL_FLOAT_DISABLED
+       is returned depending on the specific floating-point functionality
+       that is disabled and the type of floating-point input. */
    QCBOR_ERR_FLOAT_DATE_DISABLED = 39,
 
    /** Support for half-precision float decoding is disabled. */

--- a/inc/qcbor/qcbor_decode.h
+++ b/inc/qcbor/qcbor_decode.h
@@ -401,9 +401,16 @@ typedef struct _QCBORItem {
       /** The value for @c uDataType @ref QCBOR_TYPE_FLOAT. */
       float       fnum;
 #endif /* USEFULBUF_DISABLE_ALL_FLOAT */
-      /** The value for @c uDataType @ref QCBOR_TYPE_DATE_EPOCH.
-       *  Floating-point dates that are NaN, +Inifinity or -Inifinity
-       *  result in the @ref QCBOR_ERR_DATE_OVERFLOW error. */
+      /** The value for @c uDataType @ref QCBOR_TYPE_DATE_EPOCH, the
+       *  number of seconds after or before Jan 1, 1970. This has a
+       *  range of 500 billion years. Floating-point dates are
+       *  converted to this integer + fractional value. If the input
+       *  value is beyond the 500 billion-year range (e.g., +/i
+       *  infinity, large floating point values, NaN)
+       *  @ref QCBOR_ERR_DATE_OVERFLOW will be returned. If the input
+       *  is floating-point and QCBOR has been compiled with
+       *  floating-point disabled, one of the various floating-point
+       *  disabled errors will be returned. */
       struct {
          int64_t  nSeconds;
 #ifndef USEFULBUF_DISABLE_ALL_FLOAT
@@ -893,7 +900,6 @@ void QCBORDecode_SetUpAllocator(QCBORDecodeContext *pCtx,
  * | @ref QCBOR_ERR_HALF_PRECISION_DISABLED    | Library compiled with half-precision disabled and half-precision input encountered |
  * | @ref QCBOR_ERR_INDEF_LEN_ARRAYS_DISABLED  | Library compiled with indefinite maps and arrays  disabled and indefinite map or array encountered |
  * | @ref QCBOR_ERR_INDEF_LEN_STRINGS_DISABLED | Library compiled with indefinite strings disabled and indefinite string encountered |
- * | @ref QCBOR_ERR_FLOAT_DATE_DISABLED        | Library compiled with floating-point disabled and floating-point date encountered |
  * | @ref QCBOR_ERR_ALL_FLOAT_DISABLED             | Library compiled with floating-point support turned off. |
  * | __Resource exhaustion errors__  ||
  * | @ref QCBOR_ERR_STRING_ALLOCATE | The string allocator is unable to allocate more memory |

--- a/inc/qcbor/qcbor_spiffy_decode.h
+++ b/inc/qcbor/qcbor_spiffy_decode.h
@@ -1019,25 +1019,33 @@ static void QCBORDecode_GetDaysStringInMapSZ(QCBORDecodeContext *pCtx,
 
  @param[in] pCtx             The decode context.
  @param[in] uTagRequirement  One of @c QCBOR_TAG_REQUIREMENT_XXX.
- @param[out] pnTime            The decoded epoch date.
+ @param[out] pnTime          The decoded epoch date.
 
  This decodes the standard CBOR epoch date/time tag, integer tag
- number of 1, or encoded CBOR that is not a tag, but borrows the
- content format.
+ number of 1. This will also decode any integer or floating-point
+ number as an epoch date (a tag 1 epoch date is just an integer or
+ floating-point number).
 
- This will handle floating-point dates, but always returns them as an
- @c int64_t discarding the fractional part. Use QCBORDecode_GetNext()
- instead of this to get the fractional part.
+ This will set @ref QCBOR_ERR_DATE_OVERFLOW if the input integer will
+ not fit in an @c int64_t. Note that an @c int64_t can represent a
+ range of over 500 billion years with one second resolution.
+
+ Floating-point dates are always returned as an @c int64_t. The
+ fractional part is discarded.
+
+ If the input is a floating-point date and the QCBOR library is
+ compiled with some or all floating-point features, the following
+ errors will be set.  If the input is half-precision and
+ half-precision is disabled @ref QCBOR_ERR_HALF_PRECISION_DISABLED is
+ set. This function needs hardware floating-point to convert the
+ floating-point value to an integer so if HW floating point is
+ disabled QCBOR_ERR_HW_FLOAT_DISABLED is set. If all floating-point is
+ disabled then @ref QCBOR_ERR_ALL_FLOAT_DISABLED is set.  A previous
+ version of this function would return @ref  QCBOR_ERR_FLOAT_DATE_DISABLED
+ in some, but not all, cases when floating-point decoding was disabled.
 
  Floating-point dates that are plus infinity, minus infinity or NaN
- (not-a-number) will result in the @ref QCBOR_ERR_DATE_OVERFLOW
- error. If the QCBOR library is compiled with hardware floating-point disabled,
- @ref QCBOR_ERR_HW_FLOAT_DISABLED is set. If compiled with preferred
- float disabled, half-precision dates will result in the @ref
- QCBOR_ERR_HALF_PRECISION_DISABLED error.
-
- If the QCBOR library is compiled with floating-point disabled,
- @ref QCBOR_ERR_ALL_FLOAT_DISABLED is set.
+ (not-a-number) will result in the @ref QCBOR_ERR_DATE_OVERFLOW error.
 
  Please see @ref Decode-Errors-Overview "Decode Errors Overview".
 

--- a/inc/qcbor/qcbor_spiffy_decode.h
+++ b/inc/qcbor/qcbor_spiffy_decode.h
@@ -1034,14 +1034,14 @@ static void QCBORDecode_GetDaysStringInMapSZ(QCBORDecodeContext *pCtx,
  fractional part is discarded.
 
  If the input is a floating-point date and the QCBOR library is
- compiled with some or all floating-point features, the following
- errors will be set.  If the input is half-precision and
+ compiled with some or all floating-point features disabled, the
+ following errors will be set.  If the input is half-precision and
  half-precision is disabled @ref QCBOR_ERR_HALF_PRECISION_DISABLED is
  set. This function needs hardware floating-point to convert the
  floating-point value to an integer so if HW floating point is
  disabled QCBOR_ERR_HW_FLOAT_DISABLED is set. If all floating-point is
  disabled then @ref QCBOR_ERR_ALL_FLOAT_DISABLED is set.  A previous
- version of this function would return @ref  QCBOR_ERR_FLOAT_DATE_DISABLED
+ version of this function would return @ref QCBOR_ERR_FLOAT_DATE_DISABLED
  in some, but not all, cases when floating-point decoding was disabled.
 
  Floating-point dates that are plus infinity, minus infinity or NaN

--- a/src/qcbor_decode.c
+++ b/src/qcbor_decode.c
@@ -1957,7 +1957,7 @@ static QCBORError DecodeDateEpoch(QCBORItem *pDecodedItem)
           *
           * The factor of 0x7ff is added/subtracted to avoid a
           * rounding error in the wrong direction when the compiler
-          * computes these constants. There is rounding because an
+          * computes these constants. There is rounding because a
           * 64-bit integer has 63 bits of precision where a double
           * only has 53 bits. Without the 0x7ff factor, the compiler
           * may round up and produce a double for the bounds check
@@ -1966,7 +1966,7 @@ static QCBORError DecodeDateEpoch(QCBORItem *pDecodedItem)
           *
           * Without the 0x7ff there is a ~30 minute range of time
           * values 10 billion years in the past and in the future
-          * where this code could go wrong. Some compilers correctly
+          * where this code could go wrong. Some compilers
           * generate a warning or error without the 0x7ff.
           */
          const double dDateMax = (double)(INT64_MAX - 0x7ff);
@@ -1984,7 +1984,7 @@ static QCBORError DecodeDateEpoch(QCBORItem *pDecodedItem)
       }
 #else /* QCBOR_DISABLE_FLOAT_HW_USE */
 
-         uReturn = QCBOR_ERR_FLOAT_DATE_DISABLED;
+         uReturn = QCBOR_ERR_HW_FLOAT_DISABLED;
          goto Done;
 
 #endif /* QCBOR_DISABLE_FLOAT_HW_USE */
@@ -5218,9 +5218,9 @@ DoubleConvertAll(const QCBORItem *pItem, uint32_t uConvertTypes, double *pdValue
 {
 #ifndef QCBOR_DISABLE_FLOAT_HW_USE
    /*
-   https://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html
-
-   */
+    * What Every Computer Scientist Should Know About Floating-Point Arithmetic
+    * https://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html
+    */
    switch(pItem->uDataType) {
 
 #ifndef QCBOR_DISABLE_EXP_AND_MANTISSA


### PR DESCRIPTION
The QCBOR_ERR_FLOAT_DATE_DISABLED is no longer returned

The code for the test cases for float disabling are simpler and give more test coverage.
