### PR TITLE
CMakeLists.txt: Export include directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,6 @@ project(qcbor
 
 set(CMAKE_C_FLAGS "-pedantic -Wall -O3 -ffunction-sections")
 
-include_directories(inc)
-
 set(SOURCE
 	src/ieee754.c
 	src/qcbor_decode.c
@@ -17,3 +15,5 @@ set(SOURCE
 ) 
 
 add_library(qcbor ${SOURCE})
+
+target_include_directories(qcbor PUBLIC inc)


### PR DESCRIPTION
This allows other projects to include this project by add_subdirectory
or FetchContent and then depend on the qcbor target without needing to
set the include paths themselves.

See note at bottom of this page:
https://cmake.org/cmake/help/latest/command/include_directories.html

Signed-off-by: Roy van Putten <roy@30mhz.com>