### PR TITLE
New encode feature allows direct writing of byte string value

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,7 +21,7 @@ few days.
 
 When the fix has been created, it will be privately verified with the party that reported it.
 Only after the fix has been verified and the reporter has had a chance to integrate the fix,
-will be be made available as a public commit in GitHub.
+will it be made available as a public commit in GitHub.
 
 If the reporter doesn't respond or can't integrate the fix, it will be made public after 30 days.
 

--- a/inc/qcbor/UsefulBuf.h
+++ b/inc/qcbor/UsefulBuf.h
@@ -1,6 +1,6 @@
 /*============================================================================
  Copyright (c) 2016-2018, The Linux Foundation.
- Copyright (c) 2018-2021, Laurence Lundblade.
+ Copyright (c) 2018-2022, Laurence Lundblade.
  Copyright (c) 2021, Arm Limited. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -42,6 +42,7 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
  when         who             what, where, why
  --------     ----            --------------------------------------------------
+ 4/11/2022    llundblade      Add GetOutPlace and Advance to UsefulOutBuf.
  9/21/2021    llundbla        Clarify UsefulOutBuf size calculation mode
  8/8/2021     dthaler/llundbla Work with C++ without compiler extensions
  5/11/2021    llundblade      Improve comments and comment formatting.
@@ -1287,9 +1288,9 @@ static inline int UsefulOutBuf_IsBufferNULL(UsefulOutBuf *pUOutBuf);
 
 
 /**
- *@brief Returns pointer and length of the output buffer not yet used.
+ * @brief Returns pointer and length of the output buffer not yet used.
  *
- * @param[in] pUOutBuf  Pointer to the @ref UsefulOutBuf
+ * @param[in] pUOutBuf  Pointer to the @ref UsefulOutBuf.
  *
  * @return pointer and length of output buffer not used.
  *
@@ -1298,12 +1299,12 @@ static inline int UsefulOutBuf_IsBufferNULL(UsefulOutBuf *pUOutBuf);
  * change the output buffer or state. It just returns a pointer
  * and length of the bytes remaining.
  *
- * This is useful to avoid having the bytes to be written all
- * in a contiguous buffer. It use can save memory. A good
+ * This is useful to avoid having the bytes to be added all
+ * in a contiguous buffer. Its use can save memory. A good
  * example is in the COSE encrypt implementation where
  * the output of the symmetric cipher can go directly
  * into the output buffer, rather than having to go into
- * an intermediate.
+ * an intermediate buffer.
  *
  * See UsefulOutBuf_Advance() which is used to tell
  * UsefulOutBuf how much was written.
@@ -1316,23 +1317,21 @@ UsefulOutBuf_GetOutPlace(UsefulOutBuf *pUOutBuf);
 
 
 /**
- *@brief Advance the amount output assuming it was written by the caller.
+ * @brief Advance the amount output assuming it was written by the caller.
  *
- * @param[in] pUOutBuf  Pointer to the @ref UsefulOutBuf
- * @param[in] uAmount  The amount to advance
+ * @param[in] pUOutBuf  Pointer to the @ref UsefulOutBuf.
+ * @param[in] uAmount  The amount to advance.
  *
  * This advances the position in the output buffer
  * by \c uAmount. This assumes that the
- * caller has written uAmount to the pointer obtained
+ * caller has written \c uAmount to the pointer obtained
  * with UsefulOutBuf_GetOutPlace().
- *
- * See UsefulOutBuf_GetOutPlace() which is used to
- * get the pointer to write to.
  *
  * Warning: this bypasses the buffer safety provided by
  * UsefulOutBuf!
  */
-void UsefulOutBuf_Advance(UsefulOutBuf *pUOutBuf, size_t uAmount);
+void
+UsefulOutBuf_Advance(UsefulOutBuf *pUOutBuf, size_t uAmount);
 
 
 /**
@@ -2180,12 +2179,17 @@ static inline int UsefulOutBuf_IsBufferNULL(UsefulOutBuf *pMe)
    return pMe->UB.ptr == NULL;
 }
 
+
 static inline UsefulBuf UsefulOutBuf_GetOutPlace(UsefulOutBuf *pUOutBuf)
 {
    UsefulBuf R;
 
-   R.ptr = (uint8_t *)pUOutBuf->UB.ptr + pUOutBuf->data_len;
    R.len = UsefulOutBuf_RoomLeft(pUOutBuf);
+   if(R.len > 0) {
+      R.ptr = (uint8_t *)pUOutBuf->UB.ptr + pUOutBuf->data_len;
+   } else {
+      R.ptr = NULL;
+   }
 
    return R;
 }

--- a/inc/qcbor/qcbor_common.h
+++ b/inc/qcbor/qcbor_common.h
@@ -524,7 +524,11 @@ typedef enum {
 
    /** Floating point support is completely turned off, encoding/decoding
        floating point numbers is not possible. */
-   QCBOR_ERR_ALL_FLOAT_DISABLED = 46
+   QCBOR_ERR_ALL_FLOAT_DISABLED = 46,
+
+   /** During encode, the amount given to QCBOREncode_CloseBytes() was
+       past the end of what was returned by QCBOREncode_OpenBytes(). */
+   QCBOR_ERR_ADVANCE_TOO_FAR = 47
 
    /* This is stored in uint8_t; never add values > 255 */
 } QCBORError;

--- a/inc/qcbor/qcbor_common.h
+++ b/inc/qcbor/qcbor_common.h
@@ -1,6 +1,6 @@
 /*==============================================================================
  Copyright (c) 2016-2018, The Linux Foundation.
- Copyright (c) 2018-2021, Laurence Lundblade.
+ Copyright (c) 2018-2022, Laurence Lundblade.
  Copyright (c) 2021, Arm Limited.
  All rights reserved.
 
@@ -314,7 +314,8 @@ typedef enum {
    QCBOR_ERR_TOO_MANY_CLOSES = 7,
 
    /** During encoding the number of array or map opens was not
-       matched by the number of closes. */
+       matched by the number of closes. Also occurs with opened
+       byte strings that are not closed. */
    QCBOR_ERR_ARRAY_OR_MAP_STILL_OPEN = 8,
 
 #define QCBOR_START_OF_NOT_WELL_FORMED_ERRORS 9
@@ -489,7 +490,7 @@ typedef enum {
        non-CBOR reason */
    QCBOR_ERR_CALLBACK_FAIL = 38,
 
-   /** This error code is deprecated. Instead, 
+   /** This error code is deprecated. Instead,
        \ref QCBOR_ERR_HALF_PRECISION_DISABLED,
        \ref QCBOR_ERR_HW_FLOAT_DISABLED or \ref QCBOR_ERR_ALL_FLOAT_DISABLED
        is returned depending on the specific floating-point functionality
@@ -526,9 +527,9 @@ typedef enum {
        floating point numbers is not possible. */
    QCBOR_ERR_ALL_FLOAT_DISABLED = 46,
 
-   /** During encode, the amount given to QCBOREncode_CloseBytes() was
-       past the end of what was returned by QCBOREncode_OpenBytes(). */
-   QCBOR_ERR_ADVANCE_TOO_FAR = 47
+   /** During encode, opening a byte string while a byte string is open
+       is not allowed. . */
+   QCBOR_ERR_OPEN_BYTE_STRING = 47
 
    /* This is stored in uint8_t; never add values > 255 */
 } QCBORError;

--- a/inc/qcbor/qcbor_encode.h
+++ b/inc/qcbor/qcbor_encode.h
@@ -854,7 +854,8 @@ static void QCBOREncode_AddBytesToMapN(QCBOREncodeContext *pCtx, int64_t nLabel,
  copy of it in memory. This is particularly useful if the byte string
  is large, for example, the encrypted payload of a COSE_Encrypt
  message. The payload encryption algorithm can output directly to the
- encoded CBOR buffer.
+ encoded CBOR buffer, perhaps by making it the output buffer
+ for some function (e.g. symmetric encryption) or by multiple writes.
 
  The pointer in \c pPlace is where to start writing. Writing is just
  copying bytes to the location by the pointer in \c pPlace.  Writing

--- a/inc/qcbor/qcbor_encode.h
+++ b/inc/qcbor/qcbor_encode.h
@@ -840,6 +840,31 @@ static void QCBOREncode_AddBytesToMap(QCBOREncodeContext *pCtx, const char *szLa
 static void QCBOREncode_AddBytesToMapN(QCBOREncodeContext *pCtx, int64_t nLabel, UsefulBufC Bytes);
 
 
+/*
+ The purpose of this is to be able to output the bytes that make
+ up a byte string directly to the QCBOR output buffer so you don't
+ need to have a copy of it in memory. This is particularly useful
+ if the byte string is large, for example the encrypted payload
+ of a COSE_Encrypt message.
+
+QCBOREncode_StartBytes
+   pPlace -- The pointer where the value of the byte string is written
+             and the maximum number of bytes that can be written.
+
+QCBOREncode_EndBytes
+   uAmount -- The number of bytes written into pPlace.
+
+When QCBOREncode_EndBytes is called, the correct CBOR header
+ will be inserted in front of the byte string value.
+
+ TODO: finish this documentation, write the implementation, tests the code.
+
+ */
+void QCBOREncode_StartBytes(QCBOREncodeContext *pCtx, UsefulBuf *pPlace);
+
+void QCBOREncode_EndBytes(QCBOREncodeContext *pCtx, size_t uAmount);
+
+
 /**
  @brief Add a binary UUID to the encoded output.
 

--- a/inc/qcbor/qcbor_encode.h
+++ b/inc/qcbor/qcbor_encode.h
@@ -861,6 +861,9 @@ static void QCBOREncode_AddBytesToMapN(QCBOREncodeContext *pCtx, int64_t nLabel,
  the length in \c pPlace will be writing off the end of the
  output buffer.
 
+ If there is no room in the output buffer NULLUsefulBuf will be returned and
+ there is no need to call QCBOREncode_CloseBytes().
+
  The byte string must be closed by calling QCBOREncode_CloseBytes().
 
  TODO: finish this documentation, write the implementation, test the code.
@@ -868,9 +871,11 @@ static void QCBOREncode_AddBytesToMapN(QCBOREncodeContext *pCtx, int64_t nLabel,
  */
 void QCBOREncode_OpenBytes(QCBOREncodeContext *pCtx, UsefulBuf *pPlace);
 
-void QCBOREncode_OpenBytesInMapSZ(QCBOREncodeContext *pCtx, const char *szLabel, UsefulBuf *pPlace);
+static void
+QCBOREncode_OpenBytesInMapSZ(QCBOREncodeContext *pCtx, const char *szLabel, UsefulBuf *pPlace);
 
-void QCBOREncode_OpenBytesInMapN(QCBOREncodeContext *pCtx, int64_t nLabel, UsefulBuf *pPlace);
+static void
+QCBOREncode_OpenBytesInMapN(QCBOREncodeContext *pCtx, int64_t nLabel, UsefulBuf *pPlace);
 
 
 /**
@@ -881,6 +886,9 @@ void QCBOREncode_OpenBytesInMapN(QCBOREncodeContext *pCtx, int64_t nLabel, Usefu
 
  This inserts a CBOR header at the front of the byte string value to make
  it a well-formed byte string.
+
+ If there was no call to QCBOREncode_OpenBytes() then @ref QCBOR_ERR_TOO_MANY_CLOSES is
+ set.
  */
 void QCBOREncode_CloseBytes(QCBOREncodeContext *pCtx, size_t uAmount);
 
@@ -2413,6 +2421,20 @@ QCBOREncode_AddBytesToMapN(QCBOREncodeContext *pMe, int64_t nLabel, UsefulBufC B
 {
    QCBOREncode_AddInt64(pMe, nLabel);
    QCBOREncode_AddBytes(pMe, Bytes);
+}
+
+static inline void
+QCBOREncode_OpenBytesInMapSZ(QCBOREncodeContext *pMe, const char *szLabel, UsefulBuf *pPlace)
+{
+   QCBOREncode_AddSZString(pMe, szLabel);
+   QCBOREncode_OpenBytes(pMe, pPlace);
+}
+
+static inline void
+QCBOREncode_OpenBytesInMapN(QCBOREncodeContext *pMe, int64_t nLabel, UsefulBuf *pPlace)
+{
+   QCBOREncode_AddInt64(pMe, nLabel);
+   QCBOREncode_OpenBytes(pMe, pPlace);
 }
 
 static inline void

--- a/inc/qcbor/qcbor_encode.h
+++ b/inc/qcbor/qcbor_encode.h
@@ -840,29 +840,49 @@ static void QCBOREncode_AddBytesToMap(QCBOREncodeContext *pCtx, const char *szLa
 static void QCBOREncode_AddBytesToMapN(QCBOREncodeContext *pCtx, int64_t nLabel, UsefulBufC Bytes);
 
 
-/*
- The purpose of this is to be able to output the bytes that make
- up a byte string directly to the QCBOR output buffer so you don't
+/**
+ @brief Set up to write a byte string value directly to encoded output.
+
+ @param[in] pCtx   The encoding context to add the bytes to.
+ @param[out] pPlace  Pointer and length of place to write byte string value.
+
+ See QCBOREncode_AddBytes() for the usual way to output a byte string.
+
+ The purpose of this is to output the bytes that make
+ up a byte string value directly to the QCBOR output buffer so you don't
  need to have a copy of it in memory. This is particularly useful
  if the byte string is large, for example the encrypted payload
- of a COSE_Encrypt message.
+ of a COSE_Encrypt message. The payload encryption algorithm can
+ output directly to the encoded CBOR buffer.
 
-QCBOREncode_StartBytes
-   pPlace -- The pointer where the value of the byte string is written
-             and the maximum number of bytes that can be written.
+ The pointer in \c pPlace is where to start writing. Writing is just
+ copying bytes to the location by the pointer in \c pPlace.
+ Writing past
+ the length in \c pPlace will be writing off the end of the
+ output buffer.
 
-QCBOREncode_EndBytes
-   uAmount -- The number of bytes written into pPlace.
+ The byte string must be closed by calling QCBOREncode_CloseBytes().
 
-When QCBOREncode_EndBytes is called, the correct CBOR header
- will be inserted in front of the byte string value.
-
- TODO: finish this documentation, write the implementation, tests the code.
+ TODO: finish this documentation, write the implementation, test the code.
 
  */
-void QCBOREncode_StartBytes(QCBOREncodeContext *pCtx, UsefulBuf *pPlace);
+void QCBOREncode_OpenBytes(QCBOREncodeContext *pCtx, UsefulBuf *pPlace);
 
-void QCBOREncode_EndBytes(QCBOREncodeContext *pCtx, size_t uAmount);
+void QCBOREncode_OpenBytesInMapSZ(QCBOREncodeContext *pCtx, const char *szLabel, UsefulBuf *pPlace);
+
+void QCBOREncode_OpenBytesInMapN(QCBOREncodeContext *pCtx, int64_t nLabel, UsefulBuf *pPlace);
+
+
+/**
+  @brief Close out a byte string written directly to encoded output.
+
+  @param[in] pCtx   The encoding context to add the bytes to.
+  @param[out] uAmount  The number of bytes written, the length of the byte string.
+
+ This inserts a CBOR header at the front of the byte string value to make
+ it a well-formed byte string.
+ */
+void QCBOREncode_CloseBytes(QCBOREncodeContext *pCtx, size_t uAmount);
 
 
 /**

--- a/inc/qcbor/qcbor_encode.h
+++ b/inc/qcbor/qcbor_encode.h
@@ -843,33 +843,34 @@ static void QCBOREncode_AddBytesToMapN(QCBOREncodeContext *pCtx, int64_t nLabel,
 /**
  @brief Set up to write a byte string value directly to encoded output.
 
- @param[in] pCtx   The encoding context to add the bytes to.
+ @param[in] pCtx     The encoding context to add the bytes to.
  @param[out] pPlace  Pointer and length of place to write byte string value.
 
- See QCBOREncode_AddBytes() for the usual way to output a byte string.
+ QCBOREncode_AddBytes() is the normal way to encode a byte string.
+ This is for special cases and by passes some of the pointer safety.
 
- The purpose of this is to output the bytes that make
- up a byte string value directly to the QCBOR output buffer so you don't
- need to have a copy of it in memory. This is particularly useful
- if the byte string is large, for example the encrypted payload
- of a COSE_Encrypt message. The payload encryption algorithm can
- output directly to the encoded CBOR buffer.
+ The purpose of this is to output the bytes that make up a byte string
+ value directly to the QCBOR output buffer so you don't need to have a
+ copy of it in memory. This is particularly useful if the byte string
+ is large, for example, the encrypted payload of a COSE_Encrypt
+ message. The payload encryption algorithm can output directly to the
+ encoded CBOR buffer.
 
  The pointer in \c pPlace is where to start writing. Writing is just
- copying bytes to the location by the pointer in \c pPlace.
- Writing past
- the length in \c pPlace will be writing off the end of the
+ copying bytes to the location by the pointer in \c pPlace.  Writing
+ past the length in \c pPlace will be writing off the end of the
  output buffer.
 
- If there is no room in the output buffer NULLUsefulBuf will be returned and
- there is no need to call QCBOREncode_CloseBytes().
+ If there is no room in the output buffer @ref NULLUsefulBuf will be
+ returned and there is no need to call QCBOREncode_CloseBytes().
 
  The byte string must be closed by calling QCBOREncode_CloseBytes().
 
- TODO: finish this documentation, write the implementation, test the code.
-
+ Warning: this bypasses some of the usual checks provided by QCBOR
+ against writing off the end of the encoded output buffer.
  */
-void QCBOREncode_OpenBytes(QCBOREncodeContext *pCtx, UsefulBuf *pPlace);
+void
+QCBOREncode_OpenBytes(QCBOREncodeContext *pCtx, UsefulBuf *pPlace);
 
 static void
 QCBOREncode_OpenBytesInMapSZ(QCBOREncodeContext *pCtx, const char *szLabel, UsefulBuf *pPlace);
@@ -881,14 +882,15 @@ QCBOREncode_OpenBytesInMapN(QCBOREncodeContext *pCtx, int64_t nLabel, UsefulBuf 
 /**
   @brief Close out a byte string written directly to encoded output.
 
-  @param[in] pCtx   The encoding context to add the bytes to.
+  @param[in] pCtx      The encoding context to add the bytes to.
   @param[out] uAmount  The number of bytes written, the length of the byte string.
 
- This inserts a CBOR header at the front of the byte string value to make
- it a well-formed byte string.
+ This closes out a call to QCBOREncode_OpenBytes().  This inserts a
+ CBOR header at the front of the byte string value to make it a
+ well-formed byte string.
 
- If there was no call to QCBOREncode_OpenBytes() then @ref QCBOR_ERR_TOO_MANY_CLOSES is
- set.
+ If there was no call to QCBOREncode_OpenBytes() then
+ @ref QCBOR_ERR_TOO_MANY_CLOSES is set.
  */
 void QCBOREncode_CloseBytes(QCBOREncodeContext *pCtx, size_t uAmount);
 

--- a/inc/qcbor/qcbor_private.h
+++ b/inc/qcbor/qcbor_private.h
@@ -320,6 +320,8 @@ struct _QCBORDecodeContext {
 #define CBOR_MAJOR_NONE_TYPE_RAW  9
 #define CBOR_MAJOR_NONE_TAG_LABEL_REORDER 10
 #define CBOR_MAJOR_NONE_TYPE_BSTR_LEN_ONLY 11
+#define CBOR_MAJOR_NONE_TYPE_OPEN_BSTR 12
+
 
 // Add this to types to indicate they are to be encoded as indefinite lengths
 #define QCBOR_INDEFINITE_LEN_TYPE_MODIFIER 0x80

--- a/src/UsefulBuf.c
+++ b/src/UsefulBuf.c
@@ -304,6 +304,60 @@ void UsefulOutBuf_InsertUsefulBuf(UsefulOutBuf *pMe, UsefulBufC NewData, size_t 
 
 
 /*
+ * Public function for advancing data length. See qcbor/UsefulBuf.h
+ */
+void UsefulOutBuf_Advance(UsefulOutBuf *pMe, size_t uAmount)
+{
+   /* This function is a trimmed down version of
+      UsefulOutBuf_InsertUsefulBuf() */
+
+   if(pMe->err) {
+       /* Already in error state. */
+       return;
+    }
+
+    /* 0. Sanity check the UsefulOutBuf structure
+     *
+     * A "counter measure". If magic number is not the right number it
+     * probably means me was not initialized or it was
+     * corrupted. Attackers can defeat this, but it is a hurdle and
+     * does good with very little code.
+     */
+    if(pMe->magic != USEFUL_OUT_BUF_MAGIC) {
+       pMe->err = 1;
+       return;  /* Magic number is wrong due to uninitalization or corrption */
+    }
+
+    /* Make sure valid data is less than buffer size. This would only
+     * occur if there was corruption of me, but it is also part of the
+     * checks to be sure there is no pointer arithmatic
+     * under/overflow.
+     */
+    if(pMe->data_len > pMe->UB.len) {  // Check #1
+       pMe->err = 1;
+       /* Offset of valid data is off the end of the UsefulOutBuf due
+        * to uninitialization or corruption.
+        */
+       return;
+    }
+
+    /* 1. Will it fit?
+     *
+     * WillItFit() is the same as: NewData.len <= (me->UB.len -
+     * me->data_len) Check #1 makes sure subtraction in RoomLeft will
+     * not wrap around
+     */
+    if(! UsefulOutBuf_WillItFit(pMe, uAmount)) { /* Check #2 */
+       /* The new data will not fit into the the buffer. */
+       pMe->err = 1;
+       return;
+    }
+
+   pMe->data_len += uAmount;
+}
+
+
+/*
  Public function -- see UsefulBuf.h
  */
 UsefulBufC UsefulOutBuf_OutUBuf(UsefulOutBuf *pMe)

--- a/src/UsefulBuf.c
+++ b/src/UsefulBuf.c
@@ -1,6 +1,6 @@
 /*==============================================================================
  Copyright (c) 2016-2018, The Linux Foundation.
- Copyright (c) 2018-2021, Laurence Lundblade.
+ Copyright (c) 2018-2022, Laurence Lundblade.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -41,6 +41,7 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
  when        who          what, where, why
  --------    ----         ---------------------------------------------------
+ 4/11/2022    llundblade  Add GetOutPlace and Advance to UsefulOutBuf
  3/6/2021     mcr/llundblade  Fix warnings related to --Wcast-qual
  01/28/2020  llundblade   Refine integer signedness to quiet static analysis.
  01/08/2020  llundblade   Documentation corrections & improved code formatting.
@@ -309,49 +310,53 @@ void UsefulOutBuf_InsertUsefulBuf(UsefulOutBuf *pMe, UsefulBufC NewData, size_t 
 void UsefulOutBuf_Advance(UsefulOutBuf *pMe, size_t uAmount)
 {
    /* This function is a trimmed down version of
-      UsefulOutBuf_InsertUsefulBuf() */
+    * UsefulOutBuf_InsertUsefulBuf(). This could be combined with the
+    * code in UsefulOutBuf_InsertUsefulBuf(), but that would make
+    * UsefulOutBuf_InsertUsefulBuf() bigger and this will be very
+    * rarely used.
+    */
 
    if(pMe->err) {
-       /* Already in error state. */
-       return;
-    }
+      /* Already in error state. */
+      return;
+   }
 
-    /* 0. Sanity check the UsefulOutBuf structure
-     *
-     * A "counter measure". If magic number is not the right number it
-     * probably means me was not initialized or it was
-     * corrupted. Attackers can defeat this, but it is a hurdle and
-     * does good with very little code.
-     */
-    if(pMe->magic != USEFUL_OUT_BUF_MAGIC) {
-       pMe->err = 1;
-       return;  /* Magic number is wrong due to uninitalization or corrption */
-    }
+   /* 0. Sanity check the UsefulOutBuf structure
+    *
+    * A "counter measure". If magic number is not the right number it
+    * probably means me was not initialized or it was
+    * corrupted. Attackers can defeat this, but it is a hurdle and
+    * does good with very little code.
+    */
+   if(pMe->magic != USEFUL_OUT_BUF_MAGIC) {
+      pMe->err = 1;
+      return;  /* Magic number is wrong due to uninitalization or corrption */
+   }
 
-    /* Make sure valid data is less than buffer size. This would only
-     * occur if there was corruption of me, but it is also part of the
-     * checks to be sure there is no pointer arithmatic
-     * under/overflow.
-     */
-    if(pMe->data_len > pMe->UB.len) {  // Check #1
-       pMe->err = 1;
-       /* Offset of valid data is off the end of the UsefulOutBuf due
-        * to uninitialization or corruption.
-        */
-       return;
-    }
+   /* Make sure valid data is less than buffer size. This would only
+    * occur if there was corruption of me, but it is also part of the
+    * checks to be sure there is no pointer arithmatic
+    * under/overflow.
+    */
+   if(pMe->data_len > pMe->UB.len) {  // Check #1
+      pMe->err = 1;
+      /* Offset of valid data is off the end of the UsefulOutBuf due
+       * to uninitialization or corruption.
+       */
+      return;
+   }
 
-    /* 1. Will it fit?
-     *
-     * WillItFit() is the same as: NewData.len <= (me->UB.len -
-     * me->data_len) Check #1 makes sure subtraction in RoomLeft will
-     * not wrap around
-     */
-    if(! UsefulOutBuf_WillItFit(pMe, uAmount)) { /* Check #2 */
-       /* The new data will not fit into the the buffer. */
-       pMe->err = 1;
-       return;
-    }
+   /* 1. Will it fit?
+    *
+    * WillItFit() is the same as: NewData.len <= (me->UB.len -
+    * me->data_len) Check #1 makes sure subtraction in RoomLeft will
+    * not wrap around
+    */
+   if(! UsefulOutBuf_WillItFit(pMe, uAmount)) { /* Check #2 */
+      /* The new data will not fit into the the buffer. */
+      pMe->err = 1;
+      return;
+   }
 
    pMe->data_len += uAmount;
 }

--- a/src/qcbor_encode.c
+++ b/src/qcbor_encode.c
@@ -931,6 +931,54 @@ void QCBOREncode_CancelBstrWrap(QCBOREncodeContext *pMe)
 }
 
 
+void QCBOREncode_StartBytes(QCBOREncodeContext *pMe, UsefulBuf *pPlace)
+{
+   /* Add one item to the nesting level we are in for the new map or array */
+   IncrementMapOrArrayCount(pMe);
+
+   /* The offset where the length of an array or map will get written
+    * is stored in a uint32_t, not a size_t to keep stack usage
+    * smaller. This checks to be sure there is no wrap around when
+    * recording the offset.  Note that on 64-bit machines CBOR larger
+    * than 4GB can be encoded as long as no array/map offsets occur
+    * past the 4GB mark, but the public interface says that the
+    * maximum is 4GB to keep the discussion simpler.
+    */
+   size_t uEndPosition = UsefulOutBuf_GetEndPosition(&(pMe->OutBuf));
+
+   /* QCBOR_MAX_ARRAY_OFFSET is slightly less than UINT32_MAX so this
+    * code can run on a 32-bit machine and tests can pass on a 32-bit
+    * machine. If it was exactly UINT32_MAX, then this code would not
+    * compile or run on a 32-bit machine and an #ifdef or some machine
+    * size detection would be needed reducing portability.
+    */
+   if(uEndPosition >= QCBOR_MAX_ARRAY_OFFSET) {
+      pMe->uError = QCBOR_ERR_BUFFER_TOO_LARGE;
+
+      *pPlace = NULLUsefulBuf;
+
+   } else {
+      /* Increase nesting level because this is a map or array.  Cast
+       * from size_t to uin32_t is safe because of check above.
+       */
+      // TODO: proper type constant
+      pMe->uError = Nesting_Increase(&(pMe->nesting), 200, (uint32_t)uEndPosition);
+
+      *pPlace = UsefulOutBuf_Stuff(&(pMe->OutBuf));
+   }
+}
+
+
+void QCBOREncode_EndBytes(QCBOREncodeContext *pMe, size_t uAmount)
+{
+   UsefulOutBuf_StuffDone(&(pMe->OutBuf), uAmount);
+   // TODO: sort out the major type
+   InsertCBORHead(pMe,
+                  CBOR_MAJOR_TYPE_BYTE_STRING,
+                  uAmount);
+}
+
+
 /*
  * Public function for closing arrays and maps. See qcbor/qcbor_encode.h
  */

--- a/src/qcbor_encode.c
+++ b/src/qcbor_encode.c
@@ -931,7 +931,7 @@ void QCBOREncode_CancelBstrWrap(QCBOREncodeContext *pMe)
 }
 
 
-void QCBOREncode_StartBytes(QCBOREncodeContext *pMe, UsefulBuf *pPlace)
+void QCBOREncode_OpenBytes(QCBOREncodeContext *pMe, UsefulBuf *pPlace)
 {
    /* Add one item to the nesting level we are in for the new map or array */
    IncrementMapOrArrayCount(pMe);
@@ -969,7 +969,7 @@ void QCBOREncode_StartBytes(QCBOREncodeContext *pMe, UsefulBuf *pPlace)
 }
 
 
-void QCBOREncode_EndBytes(QCBOREncodeContext *pMe, size_t uAmount)
+void QCBOREncode_CloseBytes(QCBOREncodeContext *pMe, size_t uAmount)
 {
    UsefulOutBuf_StuffDone(&(pMe->OutBuf), uAmount);
    // TODO: sort out the major type

--- a/src/qcbor_encode.c
+++ b/src/qcbor_encode.c
@@ -941,7 +941,15 @@ void QCBOREncode_OpenBytes(QCBOREncodeContext *pMe, UsefulBuf *pPlace)
 {
    *pPlace = UsefulOutBuf_GetOutPlace(&(pMe->OutBuf));
    if(!UsefulBuf_IsNULL(*pPlace)){
-      QCBOREncode_OpenMapOrArray(pMe, CBOR_MAJOR_NONE_TYPE_OPEN_BSTR);
+#ifndef QCBOR_DISABLE_ENCODE_USAGE_GUARDS
+      uint8_t uMajorType = Nesting_GetMajorType(&(pMe->nesting));
+      if(uMajorType == CBOR_MAJOR_NONE_TYPE_OPEN_BSTR) {
+         pMe->uError = QCBOR_ERR_OPEN_BYTE_STRING;
+         return;
+      }
+#endif /* QCBOR_DISABLE_ENCODE_USAGE_GUARDS */
+
+   QCBOREncode_OpenMapOrArray(pMe, CBOR_MAJOR_NONE_TYPE_OPEN_BSTR);
    }
 }
 
@@ -949,11 +957,11 @@ void QCBOREncode_OpenBytes(QCBOREncodeContext *pMe, UsefulBuf *pPlace)
 /*
  * Public function for closing a byte string. See qcbor/qcbor_encode.h
  */
-void QCBOREncode_CloseBytes(QCBOREncodeContext *pMe, size_t uAmount)
+void QCBOREncode_CloseBytes(QCBOREncodeContext *pMe, const size_t uAmount)
 {
    UsefulOutBuf_Advance(&(pMe->OutBuf), uAmount);
    if(UsefulOutBuf_GetError(&(pMe->OutBuf))) {
-      pMe->uError = QCBOR_ERR_ADVANCE_TOO_FAR;
+      /* Advance too far. Normal off-end error handling in effect here. */
       return;
    }
 

--- a/test/UsefulBuf_Tests.c
+++ b/test/UsefulBuf_Tests.c
@@ -815,4 +815,35 @@ const char *UBUTest_CopyUtil(void)
 #endif /* USEFULBUF_DISABLE_ALL_FLOAT */
 
 
+const char *UBAdvanceTest()
+{
+   UsefulOutBuf_MakeOnStack(UOB, 10);
 
+   UsefulBuf Place = UsefulOutBuf_GetOutPlace(&UOB);
+   if(Place.len != 10) {
+      return "Wrong Place";
+   }
+
+   memset(Place.ptr, 'x', Place.len/2);
+
+   UsefulOutBuf_Advance(&UOB, Place.len/2);
+
+   UsefulOutBuf_AppendByte(&UOB, 'y');
+
+   Place = UsefulOutBuf_GetOutPlace(&UOB);
+   if(Place.len != 10/2 -1 ) {
+      return "shit";
+   }
+
+   memset(Place.ptr, 'z', Place.len);
+
+   UsefulOutBuf_Advance(&UOB, Place.len);
+
+   UsefulBufC O = UsefulOutBuf_OutUBuf(&UOB);
+
+   UsefulBuf_Compare(O, UsefulBuf_FROM_SZ_LITERAL("xxxxxyzzzz"));
+
+   // TODO: check for advancing too far, full buffer, ....
+
+   return NULL;
+}

--- a/test/UsefulBuf_Tests.c
+++ b/test/UsefulBuf_Tests.c
@@ -815,7 +815,7 @@ const char *UBUTest_CopyUtil(void)
 #endif /* USEFULBUF_DISABLE_ALL_FLOAT */
 
 
-const char *UBAdvanceTest()
+const char *UBAdvanceTest(void)
 {
    #define ADVANCE_TEST_SIZE 10
    UsefulOutBuf_MakeOnStack(UOB, ADVANCE_TEST_SIZE);

--- a/test/UsefulBuf_Tests.c
+++ b/test/UsefulBuf_Tests.c
@@ -1,6 +1,6 @@
 /*==============================================================================
  Copyright (c) 2016-2018, The Linux Foundation.
- Copyright (c) 2018-2021, Laurence Lundblade.
+ Copyright (c) 2018-2022, Laurence Lundblade.
  Copyright (c) 2021, Arm Limited.
  All rights reserved.
 
@@ -817,11 +817,12 @@ const char *UBUTest_CopyUtil(void)
 
 const char *UBAdvanceTest()
 {
-   UsefulOutBuf_MakeOnStack(UOB, 10);
+   #define ADVANCE_TEST_SIZE 10
+   UsefulOutBuf_MakeOnStack(UOB, ADVANCE_TEST_SIZE);
 
    UsefulBuf Place = UsefulOutBuf_GetOutPlace(&UOB);
    if(Place.len != 10) {
-      return "Wrong Place";
+      return "GetOutPlace wrong size";
    }
 
    memset(Place.ptr, 'x', Place.len/2);
@@ -831,8 +832,8 @@ const char *UBAdvanceTest()
    UsefulOutBuf_AppendByte(&UOB, 'y');
 
    Place = UsefulOutBuf_GetOutPlace(&UOB);
-   if(Place.len != 10/2 -1 ) {
-      return "shit";
+   if(Place.len != ADVANCE_TEST_SIZE/2 -1 ) {
+      return "GetOutPlace wrong size 2";
    }
 
    memset(Place.ptr, 'z', Place.len);
@@ -843,7 +844,19 @@ const char *UBAdvanceTest()
 
    UsefulBuf_Compare(O, UsefulBuf_FROM_SZ_LITERAL("xxxxxyzzzz"));
 
-   // TODO: check for advancing too far, full buffer, ....
+   Place = UsefulOutBuf_GetOutPlace(&UOB);
+   if(Place.len != 0 || Place.ptr != NULL) {
+      return "GetOutPlace not null";
+   }
+
+   if(UsefulOutBuf_GetError(&UOB)) {
+      return "GetOutPlace error set";
+   }
+
+   UsefulOutBuf_Advance(&UOB, 1);
+   if(!UsefulOutBuf_GetError(&UOB)) {
+      return "Advance off end didn't set error";
+   }
 
    return NULL;
 }

--- a/test/UsefulBuf_Tests.h
+++ b/test/UsefulBuf_Tests.h
@@ -50,4 +50,6 @@ const char *  UIBTest_IntegerFormat(void);
 const char *  UBUTest_CopyUtil(void);
 #endif /* USEFULBUF_DISABLE_ALL_FLOAT */
 
+const char * UBAdvanceTest(void);
+
 #endif

--- a/test/qcbor_decode_tests.c
+++ b/test/qcbor_decode_tests.c
@@ -1,6 +1,6 @@
 /*==============================================================================
  Copyright (c) 2016-2018, The Linux Foundation.
- Copyright (c) 2018-2021, Laurence Lundblade.
+ Copyright (c) 2018-2022, Laurence Lundblade.
  Copyright (c) 2021, Arm Limited.
  All rights reserved.
 

--- a/test/qcbor_encode_tests.h
+++ b/test/qcbor_encode_tests.h
@@ -1,6 +1,6 @@
 /*==============================================================================
  Copyright (c) 2016-2018, The Linux Foundation.
- Copyright (c) 2018-2021, Laurence Lundblade.
+ Copyright (c) 2018-2022, Laurence Lundblade.
  All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -40,11 +40,6 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
  - All the functions in qcbor_encode.h are called once in the aggregation of all
    the tests below.
-
- - All the types that are supported are given as input and parsed by these tests
-
- - There is some hostile input such as invalid lengths and CBOR too complex
-   and types this parser doesn't handle
 
  */
 
@@ -141,10 +136,11 @@ int32_t RTICResultsTest(void);
  */
 int32_t AllAddMethodsTest(void);
 
+
 /*
  The binary string wrapping of maps and arrays used by COSE
  */
-int32_t  BstrWrapTest(void);
+int32_t BstrWrapTest(void);
 
 
 /*
@@ -188,6 +184,12 @@ int32_t EncodeErrorTests(void);
  test here exercises it in some way.
  */
 int32_t QCBORHeadTest(void);
+
+
+/* Fully test QCBOREncode_OpenBytes(), QCBOREncode_CloseBytes()
+ * and friends.
+ */
+int32_t OpenCloseBytesTest(void);
 
 
 

--- a/test/run_tests.c
+++ b/test/run_tests.c
@@ -66,6 +66,7 @@ static test_entry2 s_tests2[] = {
 
 
 static test_entry s_tests[] = {
+    TEST_ENTRY(OpenCloseBytesTest),
     TEST_ENTRY(EnterBstrTest),
     TEST_ENTRY(IntegerConvertTest),
     TEST_ENTRY(EnterMapTest),

--- a/test/run_tests.c
+++ b/test/run_tests.c
@@ -60,7 +60,8 @@ static test_entry2 s_tests2[] = {
     TEST_ENTRY(UOBTest_BoundaryConditionsTest),
     TEST_ENTRY(UBMacroConversionsTest),
     TEST_ENTRY(UBUtilTests),
-    TEST_ENTRY(UIBTest_IntegerFormat)
+    TEST_ENTRY(UIBTest_IntegerFormat),
+    TEST_ENTRY(UBAdvanceTest)
 };
 
 


### PR DESCRIPTION
This is useful for COSE_Encrypt and other things that might encode large byte strings.

Rather than having to have a copy of a would-be byte string value in memory, it can be written directly to the QCBOR output buffer. 

(This PR is just a crude start. It's not actually working yet)