### PR TITLE
Fix test failures related to extraneously map/array/bstr closes

### DIFF
--- a/test/qcbor_encode_tests.c
+++ b/test/qcbor_encode_tests.c
@@ -1944,7 +1944,7 @@ int32_t BstrWrapErrorTest()
    if(uError != QCBOR_ERR_ARRAY_NESTING_TOO_DEEP) {
       return (int32_t)(300 + uError);
    }
-
+   
    return 0;
 }
 
@@ -2487,7 +2487,6 @@ int32_t EncodeErrorTests()
       // Error fetch failed.
       return -122;
    }
-   QCBOREncode_CloseArray(&EC);
    QCBOREncode_CloseArray(&EC);
    if(QCBOREncode_FinishGetSize(&EC, &xx) != QCBOR_ERR_BUFFER_TOO_LARGE) {
       return -2;


### PR DESCRIPTION
Undefined behavior occurred if QCBOREncode_CloseArray(), QCBOREncode_CloseMap(), or QCBOREncode_CloseBstrWrap() were called more than their corresponding open was called.

This manifested as a test case failing on some platforms (but not others).

This should fix #139
