### PR TITLE
Fix error when QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS is defined

### DIFF
--- a/test/qcbor_decode_tests.c
+++ b/test/qcbor_decode_tests.c
@@ -6050,6 +6050,8 @@ int32_t IntegerConvertTest()
    return 0;
 }
 
+#ifndef QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS
+
 int32_t CBORTestIssue134()
 {
    QCBORDecodeContext DCtx;
@@ -6072,6 +6074,8 @@ int32_t CBORTestIssue134()
 
    return uCBORError;
 }
+
+#endif /* QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS */
 
 int32_t CBORSequenceDecodeTests(void)
 {


### PR DESCRIPTION
A problem with the test fan out was introduced with fix to #135