### PR TITLE
Fix compiler warning in test code

### DIFF
--- a/test/qcbor_decode_tests.c
+++ b/test/qcbor_decode_tests.c
@@ -6072,7 +6072,7 @@ int32_t CBORTestIssue134()
 
    uCBORError = QCBORDecode_Finish(&DCtx);
 
-   return uCBORError;
+   return (int32_t)uCBORError;
 }
 
 #endif /* QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS */


### PR DESCRIPTION
Fix simple compiler warning for some stricter compiler settings.