### PR TITLE
Documentation and #define for QCBOR 1.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,18 +168,15 @@ QCBOR.
 
 ## Code Status
 
+The current version is v1.1, a small feature addition and bug fix
+release over QCBOR 1.0.
+
 Code has been stable for over a year. The last major change was in
 fall of 2020. 
 
 QCBOR was originally developed by Qualcomm. It was [open sourced
 through CAF](https://source.codeaurora.org/quic/QCBOR/QCBOR/) with a
 permissive Linux license, September 2018 (thanks Qualcomm!).
-
-This code in [Laurence's
-GitHub](https://github.com/laurencelundblade/QCBOR) has diverged from
-the CAF source in 2018 with some simplifications, tidying up and feature
-additions.
-
 
 ## Building
 

--- a/inc/qcbor/qcbor_common.h
+++ b/inc/qcbor/qcbor_common.h
@@ -39,6 +39,21 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /**
  @file qcbor_common.h
 
+ Types and defines common to QCBOR encoding and decoding.
+*/
+
+
+/**
+ * This define indicates QCBOR v1.1.
+ *
+ * There are no backwards compatibiliy issues with QCBOR 1.0.
+ *
+ * The only new API is QCBOREncode_OpenBytes() and related.
+ */
+#define QCBOR_1_1
+
+
+/**
  This define indicates a version of QCBOR that supports spiffy decode,
  the decode functions found in qcbor_spiffy_decode.h.
 


### PR DESCRIPTION
No code change. Just ways to mark this as a 1.1 release.