### PR TITLE
Simplify wcast qual suppress

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(SOURCE
 	src/qcbor_encode.c
 	src/qcbor_err_to_str.c
 	src/UsefulBuf.c
-) 
+)
 
 add_library(qcbor ${SOURCE})
 

--- a/example.c
+++ b/example.c
@@ -307,7 +307,7 @@ Done:
 }
 
 
-int32_t RunQCborExample()
+int32_t RunQCborExample(void)
 {
    CarEngine                 InitialEngine;
    CarEngine                 DecodedEngine;

--- a/inc/qcbor/UsefulBuf.h
+++ b/inc/qcbor/UsefulBuf.h
@@ -673,15 +673,8 @@ static inline UsefulBuf UsefulBufC_Unconst(const UsefulBufC UBC)
 {
    UsefulBuf UB;
 
-   // See UsefulBuf_Unconst() implementation for comment on pragmas
-#ifndef _MSC_VER
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wcast-qual"
-#endif
-   UB.ptr = (void *)UBC.ptr;
-#ifndef _MSC_VER
-#pragma GCC diagnostic pop
-#endif
+   // See UsefulBuf_Unconst() implementation for comment
+   UB.ptr = (void *)(uintptr_t)UBC.ptr;
 
    UB.len = UBC.len;
 
@@ -1759,16 +1752,9 @@ static inline UsefulBuf UsefulBuf_Unconst(const UsefulBufC UBC)
    UsefulBuf UB;
 
    /* -Wcast-qual is a good warning flag to use in general. This is
-    * the one place in UsefulBuf where it needs to be quieted. Since
-    * clang supports GCC pragmas, this works for clang too. */
-#ifndef _MSC_VER
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wcast-qual"
-#endif
-   UB.ptr = (void *)UBC.ptr;
-#ifndef _MSC_VER
-#pragma GCC diagnostic pop
-#endif
+    * the one place in UsefulBuf where it needs to be quieted.
+    */
+   UB.ptr = (void *)(uintptr_t)UBC.ptr;
 
    UB.len = UBC.len;
 

--- a/src/qcbor_decode.c
+++ b/src/qcbor_decode.c
@@ -501,18 +501,11 @@ DecodeNesting_GetPreviousBoundedEnd(const QCBORDecodeNesting *pMe)
 static inline void
 StringAllocator_Free(const QCBORInternalAllocator *pMe, const void *pMem)
 {
-   /* These pragmas allow the "-Wcast-qual" warnings flag to be set for
-    * gcc and clang. This is the one place where the const needs to be
-    * cast away so const can be use in the rest of the code.
+   /* This cast to uintptr_t suppresses the "-Wcast-qual" warnings.
+    * This is the one place where the const needs to be cast away so const can
+    * be use in the rest of the code.
     */
-#ifndef _MSC_VER
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wcast-qual"
-#endif
-   (pMe->pfAllocator)(pMe->pAllocateCxt, (void *)pMem, 0);
-#ifndef _MSC_VER
-#pragma GCC diagnostic pop
-#endif
+   (pMe->pfAllocator)(pMe->pAllocateCxt, (void *)(uintptr_t)pMem, 0);
 }
 
 // StringAllocator_Reallocate called with pMem NULL is
@@ -523,14 +516,7 @@ StringAllocator_Reallocate(const QCBORInternalAllocator *pMe,
                            size_t uSize)
 {
    /* See comment in StringAllocator_Free() */
-#ifndef _MSC_VER
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wcast-qual"
-#endif
-   return (pMe->pfAllocator)(pMe->pAllocateCxt, (void *)pMem, uSize);
-#ifndef _MSC_VER
-#pragma GCC diagnostic pop
-#endif
+   return (pMe->pfAllocator)(pMe->pAllocateCxt, (void *)(uintptr_t)pMem, uSize);
 }
 
 static inline UsefulBuf
@@ -543,16 +529,9 @@ static inline void
 StringAllocator_Destruct(const QCBORInternalAllocator *pMe)
 {
    /* See comment in StringAllocator_Free() */
-#ifndef _MSC_VER
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wcast-qual"
-#endif
    if(pMe->pfAllocator) {
       (pMe->pfAllocator)(pMe->pAllocateCxt, NULL, 0);
    }
-#ifndef _MSC_VER
-#pragma GCC diagnostic pop
-#endif
 }
 #endif /* QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS */
 

--- a/test/float_tests.c
+++ b/test/float_tests.c
@@ -127,7 +127,7 @@ inline static bool CheckDouble(double d, uint64_t u)
 }
 
 
-int32_t HalfPrecisionDecodeBasicTests()
+int32_t HalfPrecisionDecodeBasicTests(void)
 {
    UsefulBufC HalfPrecision = UsefulBuf_FROM_BYTE_ARRAY_LITERAL(spExpectedHalf);
 
@@ -247,7 +247,7 @@ int32_t HalfPrecisionDecodeBasicTests()
 
 
 
-int32_t HalfPrecisionAgainstRFCCodeTest()
+int32_t HalfPrecisionAgainstRFCCodeTest(void)
 {
     for(uint32_t uHalfP = 0; uHalfP < 0xffff; uHalfP += 60) {
         unsigned char x[2];
@@ -441,7 +441,7 @@ static const uint8_t spExpectedSmallest[] = {
 #define MAKE_DOUBLE(x) UsefulBufUtil_CopyUint64ToDouble(x)
 
 
-int32_t DoubleAsSmallestTest()
+int32_t DoubleAsSmallestTest(void)
 {
    UsefulBuf_MAKE_STACK_UB(EncodedHalfsMem, sizeof(spExpectedSmallest));
 
@@ -700,7 +700,7 @@ static const uint8_t spExpectedFloatsNoHalf[] = {
          0x18, 0x6A,
           0xFA, 0x00, 0x00, 0x00, 0x00};
 
-int32_t GeneralFloatEncodeTests()
+int32_t GeneralFloatEncodeTests(void)
 {
    UsefulBufC ExpectedFloats;
 #ifndef QCBOR_DISABLE_PREFERRED_FLOAT
@@ -774,7 +774,7 @@ static int CHECK_EXPECTED_DOUBLE(double val, double expected)
 #endif /* USEFULBUF_DISABLE_ALL_FLOAT */
 
 
-int32_t GeneralFloatDecodeTests()
+int32_t GeneralFloatDecodeTests(void)
 {
    QCBORItem          Item;
    QCBORError         uErr;

--- a/test/qcbor_decode_tests.c
+++ b/test/qcbor_decode_tests.c
@@ -484,7 +484,7 @@ static const uint8_t spTooSmallNegative[] = {
    Tests the decoding of lots of different integers sizes
    and values.
  */
-int32_t IntegerValuesParseTest()
+int32_t IntegerValuesParseTest(void)
 {
    int nReturn;
    QCBORDecodeContext DCtx;
@@ -691,7 +691,7 @@ Done:
 
 
 
-int32_t SimpleArrayTest()
+int32_t SimpleArrayTest(void)
 {
    uint8_t *pEncoded;
    size_t  nEncodedLen;
@@ -898,7 +898,7 @@ static int32_t CheckEmpties(UsefulBufC input, bool bCheckCounts)
 }
 
 
-int32_t EmptyMapsAndArraysTest()
+int32_t EmptyMapsAndArraysTest(void)
 {
    int nResult;
    nResult = CheckEmpties(UsefulBuf_FROM_BYTE_ARRAY_LITERAL(sEmpties),
@@ -966,7 +966,7 @@ static const uint8_t spDeepArrays[] = {
    0x81, 0x81, 0x81, 0x81, 0x81, 0x81, 0x81, 0x81,
    0x81, 0x80};
 
-int32_t ParseDeepArrayTest()
+int32_t ParseDeepArrayTest(void)
 {
    QCBORDecodeContext DCtx;
    int nReturn = 0;
@@ -999,7 +999,7 @@ static const uint8_t spTooDeepArrays[] = {
    0x81, 0x81, 0x81, 0x81, 0x81, 0x81, 0x81, 0x81,
    0x80};
 
-int32_t ParseTooDeepArrayTest()
+int32_t ParseTooDeepArrayTest(void)
 {
    QCBORDecodeContext DCtx;
    int nReturn = 0;
@@ -1030,7 +1030,7 @@ int32_t ParseTooDeepArrayTest()
 
 
 
-int32_t ShortBufferParseTest()
+int32_t ShortBufferParseTest(void)
 {
    int nResult = 0;
 
@@ -1054,7 +1054,7 @@ Done:
 
 
 
-int32_t ShortBufferParseTest2()
+int32_t ShortBufferParseTest2(void)
 {
    uint8_t *pEncoded;
    int      nReturn;
@@ -1214,7 +1214,7 @@ static int32_t ParseMapTest1(QCBORDecodeMode nMode)
  Decode and thoroughly check a moderately complex
  set of maps in the QCBOR_DECODE_MODE_MAP_AS_ARRAY mode.
  */
-int32_t ParseMapAsArrayTest()
+int32_t ParseMapAsArrayTest(void)
 {
    QCBORDecodeContext DCtx;
    QCBORItem Item;
@@ -1637,7 +1637,7 @@ static int32_t ExtraBytesTest(int nLevel)
 
 
 
-int32_t ParseMapTest()
+int32_t ParseMapTest(void)
 {
    // Parse a moderatly complex map structure very thoroughly
    int32_t nResult = ParseMapTest1(QCBOR_DECODE_MODE_NORMAL);
@@ -1672,7 +1672,7 @@ static const uint8_t spSimpleValues[] = {
    0xf8, 0x00, 0xf8, 0x13, 0xf8, 0x1f, 0xf8, 0x20,
    0xf8, 0xff};
 
-int32_t ParseSimpleTest()
+int32_t ParseSimpleTest(void)
 {
    QCBORDecodeContext DCtx;
    QCBORItem Item;
@@ -1748,7 +1748,7 @@ int32_t ParseSimpleTest()
 }
 
 
-int32_t NotWellFormedTests()
+int32_t NotWellFormedTests(void)
 {
    // Loop over all the not-well-formed instance of CBOR
    // that are test vectors in not_well_formed_cbor.h
@@ -2138,7 +2138,7 @@ static const struct FailInput Failures[] = {
    // Text string should have 2^64 bytes, but has 3
    { {(uint8_t[]){0x7b, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
                   0x01, 0x02, 0x03}, 6}, QCBOR_ERR_HIT_END },
-#else 
+#else
    // Byte string should have 2^32-15 bytes, but has one
    { {(uint8_t[]){0x5a, 0x00, 0x00, 0xff, 0xf0, 0x00}, 6}, QCBOR_ERR_HIT_END },
    // Byte string should have 2^32-15 bytes, but has one
@@ -2235,7 +2235,7 @@ static const struct FailInput Failures[] = {
 
 };
 
-int32_t DecodeFailureTests()
+int32_t DecodeFailureTests(void)
 {
    int32_t nResult;
 
@@ -2335,7 +2335,7 @@ static void ComprehensiveInputRecurser(uint8_t *pBuf, size_t nLen, size_t nLenMa
 }
 
 
-int32_t ComprehensiveInputTest()
+int32_t ComprehensiveInputTest(void)
 {
    // Size 2 tests 64K inputs and runs quickly
    uint8_t pBuf[2];
@@ -2346,7 +2346,7 @@ int32_t ComprehensiveInputTest()
 }
 
 
-int32_t BigComprehensiveInputTest()
+int32_t BigComprehensiveInputTest(void)
 {
    // size 3 tests 16 million inputs and runs OK
    // in seconds on fast machines. Size 4 takes
@@ -2434,7 +2434,7 @@ static int CHECK_EXPECTED_DOUBLE(double val, double expected) {
 
 
 /* Test date decoding using GetNext() */
-int32_t DateParseTest()
+int32_t DateParseTest(void)
 {
    QCBORDecodeContext DCtx;
    QCBORItem          Item;
@@ -2679,7 +2679,7 @@ static const uint8_t spSpiffyDateTestInput[] = {
    0xa0 // Erroneous empty map as content for date
 };
 
-int32_t SpiffyDateDecodeTest()
+int32_t SpiffyDateDecodeTest(void)
 {
    QCBORDecodeContext DC;
    QCBORError         uError;
@@ -3122,7 +3122,7 @@ static const uint8_t spSpiffyTagInput[] = {
 static int32_t CheckCSRMaps(QCBORDecodeContext *pDC);
 
 
-int32_t OptTagParseTest()
+int32_t OptTagParseTest(void)
 {
    QCBORDecodeContext DCtx;
    QCBORItem          Item;
@@ -3638,7 +3638,7 @@ static const uint8_t spBigNum[] = {
 #endif /* QCBOR_DISABLE_TAGS */
 
 
-int32_t BignumParseTest()
+int32_t BignumParseTest(void)
 {
    QCBORDecodeContext DCtx;
    QCBORItem Item;
@@ -3835,7 +3835,7 @@ static const uint8_t spCSRInputIndefLen[] = {
    0x35, 0xbf, 0x24, 0x22, 0xff, 0xff};
 
 
-int32_t NestedMapTest()
+int32_t NestedMapTest(void)
 {
    QCBORDecodeContext DCtx;
 
@@ -3848,7 +3848,7 @@ int32_t NestedMapTest()
 
 
 
-int32_t StringDecoderModeFailTest()
+int32_t StringDecoderModeFailTest(void)
 {
    QCBORDecodeContext DCtx;
 
@@ -3876,7 +3876,7 @@ int32_t StringDecoderModeFailTest()
 
 
 
-int32_t NestedMapTestIndefLen()
+int32_t NestedMapTestIndefLen(void)
 {
    QCBORDecodeContext DCtx;
 
@@ -3940,7 +3940,7 @@ static int32_t parse_indeflen_nested(UsefulBufC Nested, int nNestLevel)
 }
 
 
-int32_t IndefiniteLengthNestTest()
+int32_t IndefiniteLengthNestTest(void)
 {
    UsefulBuf_MAKE_STACK_UB(Storage, 50);
    int i;
@@ -3967,7 +3967,7 @@ static const uint8_t spIndefiniteArrayBad4[] = {0x81, 0x9f};
 // confused tag
 static const uint8_t spIndefiniteArrayBad5[] = {0x9f, 0xd1, 0xff};
 
-int32_t IndefiniteLengthArrayMapTest()
+int32_t IndefiniteLengthArrayMapTest(void)
 {
    QCBORError nResult;
    // --- first test -----
@@ -4217,7 +4217,7 @@ static int CheckBigString(UsefulBufC BigString)
 }
 
 
-int32_t IndefiniteLengthStringTest()
+int32_t IndefiniteLengthStringTest(void)
 {
    QCBORDecodeContext DC;
    QCBORItem Item;
@@ -4406,7 +4406,7 @@ int32_t IndefiniteLengthStringTest()
 }
 
 
-int32_t AllocAllStringsTest()
+int32_t AllocAllStringsTest(void)
 {
    QCBORDecodeContext DC;
    QCBORError nCBORError;
@@ -5288,7 +5288,7 @@ static const struct FailInput ExponentAndMantissaFailures[] = {
 };
 
 
-int32_t ExponentAndMantissaDecodeFailTests()
+int32_t ExponentAndMantissaDecodeFailTests(void)
 {
    return ProcessFailures(ExponentAndMantissaFailures,
                           C_ARRAY_COUNT(ExponentAndMantissaFailures,
@@ -5729,7 +5729,7 @@ const unsigned char spBadConsumeInput5[] = {
 
 
 
-int32_t EnterMapTest()
+int32_t EnterMapTest(void)
 {
    QCBORItem          Item1;
    QCBORItem          ArrayItem;
@@ -6514,7 +6514,7 @@ static int32_t SetUpDecoder(QCBORDecodeContext *DCtx, UsefulBufC CBOR, UsefulBuf
 }
 
 
-int32_t IntegerConvertTest()
+int32_t IntegerConvertTest(void)
 {
    const int nNumTests = C_ARRAY_COUNT(NumberConversions,
                                        struct NumberConversion);
@@ -6587,7 +6587,7 @@ int32_t IntegerConvertTest()
 
 #ifndef QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS
 
-int32_t CBORTestIssue134()
+int32_t CBORTestIssue134(void)
 {
    QCBORDecodeContext DCtx;
    QCBORItem          Item;
@@ -6600,7 +6600,7 @@ int32_t CBORTestIssue134()
 
    UsefulBuf_MAKE_STACK_UB(StringBuf, 200);
    QCBORDecode_SetMemPool(&DCtx, StringBuf, false);
-   
+
    do {
       uCBORError = QCBORDecode_GetNext(&DCtx, &Item);
    } while (QCBOR_SUCCESS == uCBORError);
@@ -6788,7 +6788,7 @@ int32_t CBORSequenceDecodeTests(void)
 
 
 
-int32_t IntToTests()
+int32_t IntToTests(void)
 {
    int nErrCode;
    int32_t n32;
@@ -7042,7 +7042,7 @@ static const uint8_t spBreakInByteString[] = {
 };
 
 
-int32_t EnterBstrTest()
+int32_t EnterBstrTest(void)
 {
    UsefulBuf_MAKE_STACK_UB(OutputBuffer, 100);
 
@@ -7204,7 +7204,7 @@ static const uint8_t spTaggedTypes[] = {
       0x54, 0x43, 0x46, 0x49, 0x43, 0x41, 0x32
 };
 
-int32_t DecodeTaggedTypeTests()
+int32_t DecodeTaggedTypeTests(void)
 {
    QCBORDecodeContext DC;
    QCBORError         uErr;
@@ -7521,7 +7521,7 @@ static const uint8_t spMapWithIndefLenStrings[] = {
           0x5f, 0x42, 0x00, 0x01, 0x42, 0x00, 0x01, 0x41, 0x01, 0xff,
 };
 
-int32_t SpiffyIndefiniteLengthStringsTests()
+int32_t SpiffyIndefiniteLengthStringsTests(void)
 {
    QCBORDecodeContext DCtx;
 
@@ -7695,7 +7695,7 @@ static const uint8_t pWrappedByIndefiniteLength[] = {
 #endif /* QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS */
 
 
-int32_t PeekAndRewindTest()
+int32_t PeekAndRewindTest(void)
 {
    QCBORItem          Item;
    QCBORError         nCBORError;

--- a/test/qcbor_encode_tests.c
+++ b/test/qcbor_encode_tests.c
@@ -143,7 +143,7 @@ static uint8_t spBigBuf[2200];
 /*
  Some very minimal tests.
  */
-int32_t BasicEncodeTest()
+int32_t BasicEncodeTest(void)
 {
    // Very simple CBOR, a map with one boolean that is true in it
    QCBOREncodeContext EC;
@@ -686,7 +686,7 @@ static void AddAll(QCBOREncodeContext *pECtx)
 }
 
 
-int32_t AllAddMethodsTest()
+int32_t AllAddMethodsTest(void)
 {
    /* Improvement: this test should be broken down into several so it is more
     * managable. Tags and labels could be more sensible */
@@ -814,7 +814,7 @@ static const uint8_t spExpectedEncodedInts[] = {
   to expected values generated from http://cbor.me.
 
  */
-int32_t IntegerValuesTest1()
+int32_t IntegerValuesTest1(void)
 {
    QCBOREncodeContext ECtx;
    int nReturn = 0;
@@ -899,7 +899,7 @@ int32_t IntegerValuesTest1()
 static const uint8_t spExpectedEncodedSimple[] = {
    0x85, 0xf5, 0xf4, 0xf6, 0xf7, 0xa1, 0x65, 0x55, 0x4e, 0x44, 0x65, 0x66, 0xf7};
 
-int32_t SimpleValuesTest1()
+int32_t SimpleValuesTest1(void)
 {
    QCBOREncodeContext ECtx;
    int nReturn = 0;
@@ -946,7 +946,7 @@ int32_t SimpleValuesTest1()
 static const uint8_t spExpectedEncodedSimpleIndefiniteLength[] = {
    0x9f, 0xf5, 0xf4, 0xf6, 0xf7, 0xbf, 0x65, 0x55, 0x4e, 0x44, 0x65, 0x66, 0xf7, 0xff, 0xff};
 
-int32_t SimpleValuesIndefiniteLengthTest1()
+int32_t SimpleValuesIndefiniteLengthTest1(void)
 {
    QCBOREncodeContext ECtx;
    int nReturn = 0;
@@ -1141,7 +1141,7 @@ static const uint8_t EncodeLengthThirtyone[] = {
    0x31
 };
 
-int32_t EncodeLengthThirtyoneTest()
+int32_t EncodeLengthThirtyoneTest(void)
 {
    QCBOREncodeContext ECtx;
    int nReturn = 0;
@@ -1234,7 +1234,7 @@ static const uint8_t spExpectedEncodedDates[] = {
    0x30, 0x2E, 0x35, 0x32, 0x5A, 0x62, 0x53, 0x59, 0xD8, 0x64,
    0x39, 0x29, 0xB3, 0x18, 0x2D, 0x19, 0x0F, 0x9A};
 
-int32_t EncodeDateTest()
+int32_t EncodeDateTest(void)
 {
    QCBOREncodeContext ECtx;
 
@@ -1291,7 +1291,7 @@ int32_t EncodeDateTest()
 }
 
 
-int32_t ArrayNestingTest1()
+int32_t ArrayNestingTest1(void)
 {
    QCBOREncodeContext ECtx;
    int i;
@@ -1314,7 +1314,7 @@ int32_t ArrayNestingTest1()
 
 
 
-int32_t ArrayNestingTest2()
+int32_t ArrayNestingTest2(void)
 {
    QCBOREncodeContext ECtx;
    int i;
@@ -1338,7 +1338,7 @@ int32_t ArrayNestingTest2()
 
 
 
-int32_t ArrayNestingTest3()
+int32_t ArrayNestingTest3(void)
 {
    QCBOREncodeContext ECtx;
    int i;
@@ -1455,7 +1455,7 @@ static const uint8_t spEncodeRawExpected[] = {
    0xff, 0xff};
 
 
-int32_t EncodeRawTest()
+int32_t EncodeRawTest(void)
 {
    QCBOREncodeContext ECtx;
 
@@ -1578,7 +1578,7 @@ static const uint8_t spValidMapEncoded[] = {
    0x73 } ;
 
 
-int32_t MapEncodeTest()
+int32_t MapEncodeTest(void)
 {
    uint8_t *pEncodedMaps;
    size_t nEncodedMapLen;
@@ -1734,7 +1734,7 @@ static const uint8_t spExpectedRTIC[] = {
    0xaa, 0xbb, 0x01, 0x01};
 
 
-int32_t RTICResultsTest()
+int32_t RTICResultsTest(void)
 {
    const UsefulBufC Encoded = FormatRTICResults(CBOR_SIMPLEV_FALSE, 1477263730,
                                           "recent", "0xA1eC5001",
@@ -1772,7 +1772,7 @@ static const uint8_t spExpectedForBstrWrapCancel[] = {0x82, 0x19, 0x01, 0xC3, 0x
 /*
  * bstr wrapping test
  */
-int32_t BstrWrapTest()
+int32_t BstrWrapTest(void)
 {
    QCBOREncodeContext EC;
 
@@ -1896,7 +1896,7 @@ int32_t BstrWrapTest()
 
 
 
-int32_t BstrWrapErrorTest()
+int32_t BstrWrapErrorTest(void)
 {
    QCBOREncodeContext EC;
    UsefulBufC         Wrapped;
@@ -1963,7 +1963,7 @@ int32_t BstrWrapErrorTest()
    if(uError != QCBOR_ERR_ARRAY_NESTING_TOO_DEEP) {
       return (int32_t)(300 + uError);
    }
-   
+
    return 0;
 }
 
@@ -2207,7 +2207,7 @@ static int32_t DecodeNextNested2(UsefulBufC Wrapped)
 }
 
 
-int32_t BstrWrapNestTest()
+int32_t BstrWrapNestTest(void)
 {
    QCBOREncodeContext EC;
    QCBOREncode_Init(&EC, UsefulBuf_FROM_BYTE_ARRAY(spBigBuf));
@@ -2350,7 +2350,7 @@ static const uint8_t pProtectedHeaders[] = {0xa1, 0x01, 0x26};
  C.2.1. This doesn't actually verify the signature (however
  the t_cose implementation does).
  */
-int32_t CoseSign1TBSTest()
+int32_t CoseSign1TBSTest(void)
 {
    // All of this is from RFC 8152 C.2.1
    const char          *szKid     = "11";
@@ -2474,7 +2474,7 @@ int32_t CoseSign1TBSTest()
 }
 
 
-int32_t EncodeErrorTests()
+int32_t EncodeErrorTests(void)
 {
    QCBOREncodeContext EC;
    QCBORError         uErr;
@@ -2767,7 +2767,7 @@ static const uint8_t spExpectedExponentAndMantissaMap[] = {
 };
 
 
-int32_t ExponentAndMantissaEncodeTests()
+int32_t ExponentAndMantissaEncodeTests(void)
 {
    QCBOREncodeContext EC;
    UsefulBufC         EncodedExponentAndMantissa;
@@ -2879,7 +2879,7 @@ int32_t ExponentAndMantissaEncodeTests()
 #endif /* QCBOR_DISABLE_EXP_AND_MANTISSA */
 
 
-int32_t QCBORHeadTest()
+int32_t QCBORHeadTest(void)
 {
    /* This test doesn't have to be extensive, because just about every
     * other test exercises QCBOREncode_EncodeHead().

--- a/ub-example.c
+++ b/ub-example.c
@@ -214,7 +214,7 @@ ExpandxUBAdaptor(const UsefulBufC   Input,
 
 #define INPUT "xyz123xyz"
 
-int32_t RunUsefulBufExample()
+int32_t RunUsefulBufExample(void)
 {
    /* ------------ UsefulBuf examples ------------- */
    UsefulBufC Input = UsefulBuf_FROM_SZ_LITERAL(INPUT);


### PR DESCRIPTION
This PR simplifies suppressing the compiler warning 'Wcast-qual'. This method does not require pragmas.