### PR TITLE
INT64_MIN encoding so static analyzers don't complain

### DIFF
--- a/src/qcbor_encode.c
+++ b/src/qcbor_encode.c
@@ -658,8 +658,13 @@ void QCBOREncode_AddInt64(QCBOREncodeContext *me, int64_t nNum)
    uint64_t uValue;
 
    if(nNum < 0) {
-      /* In CBOR -1 encodes as 0x00 with major type negative int. */
-      uValue = (uint64_t)(-nNum - 1);
+      /* In CBOR -1 encodes as 0x00 with major type negative int.
+       * First add one as a signed integer because that will not
+       * overflow. Then change the sign as needed for encoding.  (The
+       * opposite order, changing the sign and subtracting, can cause
+       * an overflow when encoding INT64_MIN. */
+      int64_t nTmp = nNum + 1;
+      uValue = (uint64_t)-nTmp;
       uMajorType = CBOR_MAJOR_TYPE_NEGATIVE_INT;
    } else {
       uValue = (uint64_t)nNum;


### PR DESCRIPTION
This change is primarily so static analyzers don't complain. There is, and has been, test coverage for this condition for years with no reported failures. Probably QCBOR has been run on many different OS's, CPUs and with many different compilers.

This change is explicit about the application of the offset of 1 for encoding negative integers to avoid undefined behavior when encoding INT64_MIN.