### PR TITLE
Fix static analyzer complaint about INT64_MIN

### DIFF
--- a/src/qcbor_decode.c
+++ b/src/qcbor_decode.c
@@ -4465,10 +4465,10 @@ ExponentiateNN(int64_t         nMantissa,
       /* The common negative case. See next. */
       uMantissa = (uint64_t)-nMantissa;
    } else {
-      /* int64_t and uint64_t require two's complement representation
-       * of integers (and since QCBOR uses these it only works with
-       * two's complement (which is pretty much universal these
-       * days)). The range of a negative two's complement integer is
+      /* int64_t and uint64_t are always two's complement per the
+       * C standard (and since QCBOR uses these it only works with
+       * two's complement, which is pretty much universal these
+       * days). The range of a negative two's complement integer is
        * one more that than a positive, so the simple code above might
        * not work all the time because you can't simply negate the
        * value INT64_MIN because it can't be represented in an
@@ -4479,7 +4479,7 @@ ExponentiateNN(int64_t         nMantissa,
        * line does however work for all compilers.
        *
        * This does assume two's complement where -INT64_MIN ==
-       * INT64_MAX (which wouldn't be true for one's complement or
+       * INT64_MAX + 1 (which wouldn't be true for one's complement or
        * sign and magnitude (but we know we're using two's complement
        * because int64_t requires it)).
        *
@@ -4490,7 +4490,7 @@ ExponentiateNN(int64_t         nMantissa,
       uMantissa = (uint64_t)INT64_MAX+1;
    }
 
-   /* Call the exponentiator passed in for either base 2 or base 10.
+   /* Call the exponentiator passed for either base 2 or base 10.
     * Here is where most of the overflow errors are caught. */
    QCBORError uReturn = (*pfExp)(uMantissa, nExponent, &uResult);
    if(uReturn) {

--- a/test/qcbor_decode_tests.c
+++ b/test/qcbor_decode_tests.c
@@ -6132,6 +6132,18 @@ struct NumberConversion {
 static const struct NumberConversion NumberConversions[] = {
 #ifndef QCBOR_DISABLE_TAGS
    {
+      "Big float: INT64_MIN * 2e-1 to test handling of INT64_MIN",
+      {(uint8_t[]){0xC5, 0x82, 0x20,
+                               0x3B, 0x7f, 0xff, 0xff, 0xff, 0xff, 0x0ff, 0xff, 0xff,
+                               }, 15},
+      -4611686018427387904, /* INT64_MIN / 2 */
+      EXP_AND_MANTISSA_ERROR(QCBOR_SUCCESS),
+      0,
+      EXP_AND_MANTISSA_ERROR(QCBOR_ERR_NUMBER_SIGN_CONVERSION),
+      -4.6116860184273879E+18,
+      FLOAT_ERR_CODE_NO_FLOAT_HW(EXP_AND_MANTISSA_ERROR(QCBOR_SUCCESS))
+   },
+   {
       "too large to fit into int64_t",
       {(uint8_t[]){0xc3, 0x48, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, 10},
       0,


### PR DESCRIPTION
Fixes static analyzer warnings for INT64_MIN for QCBORDecode_GetInt64ConvertAll().

Adds a test for decoding of INT64_MIN by QCBORDecode_GetInt64ConvertAll()

While this wasn't tested previously, it appears the previous code did function correctly because gcc and clang have built in handling for the INT64_MIN case, thus this is label as an issue only with static analyzers. In any case, the code is correct now.

This also includes a large improvement in the comments for code that does integer conversion