### PR TITLE
Add missing extern C block in qcbor_common.h

### DIFF
--- a/inc/qcbor/qcbor_common.h
+++ b/inc/qcbor/qcbor_common.h
@@ -36,6 +36,14 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define qcbor_common_h
 
 
+#ifdef __cplusplus
+extern "C" {
+#if 0
+} // Keep editor indention formatting happy
+#endif
+#endif
+
+
 /**
  @file qcbor_common.h
 
@@ -601,5 +609,9 @@ const char *qcbor_err_to_str(QCBORError err);
  */
 #define QCBOR_MAX_CUSTOM_TAGS    16
 
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* qcbor_common_h */


### PR DESCRIPTION
Without this, C++ applications which include this header file will give functions defined in it, namely `qcbor_err_to_str`, a C++ linkage. This will cause linking to fail, since the compiled QCBOR library would have a C linkage only.

Other header files already have this extern block, it was only missing from qcbor_common.h for no particular reason.