### PR TITLE
Restore inc/qcbor.h for compatibility with QCBOR in 2020 and before

### DIFF
--- a/inc/qcbor.h
+++ b/inc/qcbor.h
@@ -1,0 +1,1 @@
+#include "qcbor/qcbor.h"


### PR DESCRIPTION
A long time ago there was just inc/qcbor.h. This file was moved to inc/qcbor/qcbor.h to facilitate installation in /usr/local/include. inc/qcbor.h was retained for a while, but got lost in a big merge in 2020. This PR restore it. It simply includes inc/qcbor/qcbor.h.