### PR TITLE
Address TODO and minor code comment improvements

### DIFF
--- a/src/qcbor_decode.c
+++ b/src/qcbor_decode.c
@@ -6334,25 +6334,27 @@ QCBOR_Private_ConvertIntToBigNum(uint64_t uInt, const UsefulBuf Buffer)
 
 
 /**
- * @brief Check and/or complete mantissa and exponent item.
+ * @brief Check and/or complete exponent and mantissa item.
  *
- * @param[in] pMe        The decoder context
- * @param[in] TagSpec    Expected type(s)
- * @param[in,out] pItem  See below
+ * @param[in] pMe        The decoder context.
+ * @param[in] TagSpec    Expected type(s).
+ * @param[in,out] pItem  See below.
  *
- * This is for decimal fractions and big floats, both of which are a
- * mantissa and exponent.
+ * This is for decimal fractions and big floats, both of which are an
+ * exponent and mantissa.
  *
- * The input item is either a fully decoded decimal faction or big
- * float, or a just the decoded first item of a decimal fraction or
- * big float.
+ * If the item item had a tag number indicating it was a
+ * decimal fraction or big float, then the input @c pItem will
+ * have been decoded as exponent and mantissa. If there was
+ * no tag number, the caller is asking this be decoded as a
+ * big float or decimal fraction and @c pItem just has the
+ * first item in an exponent and mantissa.
  *
  * On output, the item is always a fully decoded decimal fraction or
  * big float.
  *
  * This errors out if the input type does not meet the TagSpec.
  */
-// TODO: document and see tests for the bug that was fixed by this rewrite
 static QCBORError
 QCBOR_Private_ExpMantissaTypeHandler(QCBORDecodeContext         *pMe,
                                      const QCBOR_Private_TagSpec TagSpec,
@@ -6360,8 +6362,8 @@ QCBOR_Private_ExpMantissaTypeHandler(QCBORDecodeContext         *pMe,
 {
    QCBORError uErr;
 
-   /* pItem could either be an auto-decoded mantissa and exponent or
-    * the opening array of an undecoded mantissa and exponent. This
+   /* pItem could either be a decoded exponent and mantissa or
+    * the opening array of an undecoded exponent and mantissa. This
     * check will succeed on either, but doesn't say which it was.
     */
    uErr = QCBOR_Private_CheckTagRequirement(TagSpec, pItem);
@@ -6370,9 +6372,9 @@ QCBOR_Private_ExpMantissaTypeHandler(QCBORDecodeContext         *pMe,
    }
 
    if(pItem->uDataType == QCBOR_TYPE_ARRAY) {
-      /* The item is an array, which means is is an undecoded mantissa
-       * and exponent. This call consumes the items in the array and
-       * results in a decoded mantissa and exponent in pItem. This is
+      /* The item is an array, which means is is an undecoded exponent
+       * and mantissa. This call consumes the items in the array and
+       * results in a decoded exponent and mantissa in pItem. This is
        * the case where there was no tag.
        */
       uErr = QCBORDecode_Private_ExpMantissa(pMe, pItem);
@@ -6387,7 +6389,7 @@ QCBOR_Private_ExpMantissaTypeHandler(QCBORDecodeContext         *pMe,
       pItem->uDataType = QCBOR_Private_ExpMantissaDataType(TagSpec.uTaggedTypes[0], pItem);
 
       /* No need to check the type again. All that we need to know was
-       * that it decoded correctly as a mantissa and exponent. The
+       * that it decoded correctly as a exponent and mantissa. The
        * QCBOR type is set out by what was requested.
        */
    }


### PR DESCRIPTION
The TODO: was unnecessary as test coverage (EAMTests) were adequate with the original check in. Probably the TODO: was written before the tests were complete.
