### PR TITLE
Add QCBORDecoder_Tell(); traversal cursor position bug fix

### DIFF
--- a/inc/qcbor/qcbor_decode.h
+++ b/inc/qcbor/qcbor_decode.h
@@ -64,7 +64,7 @@ extern "C" {
  * nodes are either arrays or maps. Fundamentally, CBOR decoding is a
  * pre-order traversal of this tree with CBOR sequences a minor
  * exception. Calling QCBORDecode_GetNext() repeatedly will perform
- * this. It is possible to decode any CBOR by only calling
+ * this. QCBOR maintains an internal traversal cursor. It is possible to decode any CBOR by only calling
  * QCBORDecode_GetNext(), though this doesn't take advantage of many
  * QCBOR features.
  *
@@ -1032,6 +1032,38 @@ QCBORDecode_VPeekNext(QCBORDecodeContext *pCtx, QCBORItem *pDecodedItem);
  */
 QCBORError
 QCBORDecode_PeekNext(QCBORDecodeContext *pCtx, QCBORItem *pDecodedItem);
+
+
+
+/**
+ * @brief Get the current traversal cursort offset in the input CBOR.
+ *
+ * @param[in]  pCtx          The decoder context.
+ *
+ * @returns The traversal cursor offset or @c UINT32_MAX.
+
+ * The position returned is always the start of the next
+ * item that would be next decoded with QCBORDecode_VGetNext().
+ * If the cursor is at the end of the input, @c UINT32_MAX
+ * is returned.
+ *
+ * When decoding map items, the
+ * position returned is always of the label, never the
+ * value.
+ *
+ * For indefinite-length items, the CBOR break bytes are consumed
+ * when the last item in an indefinite length array or map is consumed
+ * so the cursor is at the next item to be decoded as expected.
+ *
+ * There are some special rules for the traversal cursor when
+ * fetching map items by label. See the decription of @SpiffyDecode.
+ *
+ * There is no corresponding seek because it is too complicated
+ * to restore the internal decoder state that tracks nesting.
+ */
+uint32_t
+QCBORDecode_Tell(QCBORDecodeContext *pCtx);
+
 
 
 /**

--- a/inc/qcbor/qcbor_decode.h
+++ b/inc/qcbor/qcbor_decode.h
@@ -64,9 +64,9 @@ extern "C" {
  * nodes are either arrays or maps. Fundamentally, CBOR decoding is a
  * pre-order traversal of this tree with CBOR sequences a minor
  * exception. Calling QCBORDecode_GetNext() repeatedly will perform
- * this. QCBOR maintains an internal traversal cursor. It is possible to decode any CBOR by only calling
- * QCBORDecode_GetNext(), though this doesn't take advantage of many
- * QCBOR features.
+ * this. QCBOR maintains an internal traversal cursor. It is possible
+ * to decode any CBOR by only calling QCBORDecode_GetNext(), though
+ * this doesn't take advantage of many QCBOR features.
  *
  * QCBORDecode_GetNext() returns a 56 byte structure called
  * @ref QCBORItem that describes the decoded item including:
@@ -198,8 +198,8 @@ typedef enum {
 } QCBORDecodeMode;
 
 /**
- * The maximum size of input to the decoder. Slightly less than @c UINT32_MAX
- * to make room for some special indicator values.
+ * The maximum size of input to the decoder. Slightly less than
+ * @c UINT32_MAX to make room for some special indicator values.
  */
 #define QCBOR_MAX_DECODE_INPUT_SIZE (UINT32_MAX - 2)
 
@@ -1041,21 +1041,26 @@ QCBORDecode_PeekNext(QCBORDecodeContext *pCtx, QCBORItem *pDecodedItem);
  *
  * @returns The traversal cursor offset or @c UINT32_MAX.
 
- * The position returned is always the start of the next
- * item that would be next decoded with QCBORDecode_VGetNext().
- * If the cursor is at the end of the input or in the error state, @c UINT32_MAX
- * is returned.
+ * The position returned is always the start of the next item that
+ * would be next decoded with QCBORDecode_VGetNext().  If the cursor
+ * is at the end of the input or in the error state, @c UINT32_MAX is
+ * returned.
  *
- * When decoding map items, the
- * position returned is always of the label, never the
- * value.
+ * When decoding map items, the position returned is always of the
+ * label, never the value.
  *
  * For indefinite-length arrays and maps, the break byte is consumed
- * when the last item in the array or map is consumed
- * so the cursor is at the next item to be decoded as expected.
+ * when the last item in the array or map is consumed so the cursor is
+ * at the next item to be decoded as expected.
  *
- * There are some special rules for the traversal cursor when
- * fetching map items by label. See the description of @SpiffyDecode.
+ * There are some special rules for the traversal cursor when fetching
+ * map items by label. See the description of @SpiffyDecode.
+ *
+ * When traversal is bounded because an array or map has been entered
+ * (e.g., QCBORDecode_EnterMap()) and all items in the array or map
+ * have been consumed, the position returned will be of the item
+ * outside of the array or map. The array or map must be exited before
+ * QCBORDecode_VGetNext() will decode it.
  *
  * There is no corresponding seek method because it is too complicated
  * to restore the internal decoder state that tracks nesting.
@@ -1303,7 +1308,7 @@ QCBORDecode_SetError(QCBORDecodeContext *pCtx, QCBORError uError);
  * @return 0 on success -1 if not
  *
  * When decoding an integer, the CBOR decoder will return the value as
- * an int64_t unless the integer is in the range of @c INT64_MAX and 
+ * an int64_t unless the integer is in the range of @c INT64_MAX and
  * @c UINT64_MAX. That is, unless the value is so large that it can only be
  * represented as a @c uint64_t, it will be an @c int64_t.
  *

--- a/inc/qcbor/qcbor_decode.h
+++ b/inc/qcbor/qcbor_decode.h
@@ -1062,6 +1062,13 @@ QCBORDecode_PeekNext(QCBORDecodeContext *pCtx, QCBORItem *pDecodedItem);
  * outside of the array or map. The array or map must be exited before
  * QCBORDecode_VGetNext() will decode it.
  *
+ * In many cases the position returned will be in the middle of
+ * an array or map. It will not be possible to start decoding at
+ * that location with another instance of the decoder and go to
+ * the end. It is not valid CBOR. If the input is a CBOR sequence
+ * and the position is not in the moddle of an array or map
+ * then it is possible to decode to the end.
+ *
  * There is no corresponding seek method because it is too complicated
  * to restore the internal decoder state that tracks nesting.
  */

--- a/inc/qcbor/qcbor_decode.h
+++ b/inc/qcbor/qcbor_decode.h
@@ -198,7 +198,7 @@ typedef enum {
 } QCBORDecodeMode;
 
 /**
- * The maximum size of input to the decoder. Slightly less than UINT32_MAX
+ * The maximum size of input to the decoder. Slightly less than @c UINT32_MAX
  * to make room for some special indicator values.
  */
 #define QCBOR_MAX_DECODE_INPUT_SIZE (UINT32_MAX - 2)
@@ -1034,36 +1034,34 @@ QCBORError
 QCBORDecode_PeekNext(QCBORDecodeContext *pCtx, QCBORItem *pDecodedItem);
 
 
-
 /**
  * @brief Get the current traversal cursort offset in the input CBOR.
  *
- * @param[in]  pCtx          The decoder context.
+ * @param[in]  pCtx   The decoder context.
  *
  * @returns The traversal cursor offset or @c UINT32_MAX.
 
  * The position returned is always the start of the next
  * item that would be next decoded with QCBORDecode_VGetNext().
- * If the cursor is at the end of the input, @c UINT32_MAX
+ * If the cursor is at the end of the input or in the error state, @c UINT32_MAX
  * is returned.
  *
  * When decoding map items, the
  * position returned is always of the label, never the
  * value.
  *
- * For indefinite-length items, the CBOR break bytes are consumed
- * when the last item in an indefinite length array or map is consumed
+ * For indefinite-length arrays and maps, the break byte is consumed
+ * when the last item in the array or map is consumed
  * so the cursor is at the next item to be decoded as expected.
  *
  * There are some special rules for the traversal cursor when
- * fetching map items by label. See the decription of @SpiffyDecode.
+ * fetching map items by label. See the description of @SpiffyDecode.
  *
- * There is no corresponding seek because it is too complicated
+ * There is no corresponding seek method because it is too complicated
  * to restore the internal decoder state that tracks nesting.
  */
 uint32_t
 QCBORDecode_Tell(QCBORDecodeContext *pCtx);
-
 
 
 /**
@@ -1092,7 +1090,7 @@ QCBORDecode_Tell(QCBORDecodeContext *pCtx);
  * See also @ref CBORTags, @ref Tag-Usage and @ref Tags-Overview.
  *
  * To reduce memory used by a QCBORItem, tag numbers larger than
- * UINT16_MAX are mapped so the tag numbers in @c uTags should be
+ * @c UINT16_MAX are mapped so the tag numbers in @c uTags should be
  * accessed with this function rather than directly.
  *
  * This returns @ref CBOR_TAG_INVALID64 if any error occurred when
@@ -1305,8 +1303,8 @@ QCBORDecode_SetError(QCBORDecodeContext *pCtx, QCBORError uError);
  * @return 0 on success -1 if not
  *
  * When decoding an integer, the CBOR decoder will return the value as
- * an int64_t unless the integer is in the range of @c INT64_MAX and @c
- * UINT64_MAX. That is, unless the value is so large that it can only be
+ * an int64_t unless the integer is in the range of @c INT64_MAX and 
+ * @c UINT64_MAX. That is, unless the value is so large that it can only be
  * represented as a @c uint64_t, it will be an @c int64_t.
  *
  * CBOR itself doesn't size the individual integers it carries at
@@ -1518,7 +1516,7 @@ QCBORDecode_IsTagged(QCBORDecodeContext *pCtx,
  * been decoded.
  *
  * This is not backwards compatibile in two ways. First, it is limited
- * to \ref QCBOR_MAX_TAGS_PER_ITEM items whereas previously it was
+ * to @ref QCBOR_MAX_TAGS_PER_ITEM items whereas previously it was
  * unlimited. Second, it will not inlucde the tags that QCBOR decodes
  * internally.
  *

--- a/inc/qcbor/qcbor_private.h
+++ b/inc/qcbor/qcbor_private.h
@@ -271,10 +271,10 @@ typedef struct __QCBORDecodeNesting  {
        *
        * This also records whether a level is bounded or not. All
        * byte-count tracked levels (the top-level sequence and
-       * bstr-wrapped CBOR) are bounded implicitly. Maps and arrays may or may
-       * not be bounded. They are bounded if they were Entered() and
-       * not if they were traversed with GetNext(). They are marked as
-       * bounded by uStartOffset not being UINT32_MAX.
+       * bstr-wrapped CBOR) are bounded implicitly. Maps and arrays
+       * may or may not be bounded. They are bounded if they were
+       * Entered() and not if they were traversed with GetNext(). They
+       * are marked as bounded by uStartOffset not being @c UINT32_MAX.
        */
       /*
        * If uLevelType can put in a separately indexed array, the

--- a/inc/qcbor/qcbor_private.h
+++ b/inc/qcbor/qcbor_private.h
@@ -252,13 +252,13 @@ typedef struct __QCBORDecodeNesting  {
        *   1) Byte count tracking. This is for the top level input CBOR
        *   which might be a single item or a CBOR sequence and byte
        *   string wrapped encoded CBOR.
-       *   2) Item tracking. This is for maps and arrays.
+       *   2) Item count tracking. This is for maps and arrays.
        *
        * uLevelType has value QCBOR_TYPE_BYTE_STRING for 1) and
        * QCBOR_TYPE_MAP or QCBOR_TYPE_ARRAY or QCBOR_TYPE_MAP_AS_ARRAY
        * for 2).
        *
-       * Item tracking is either for definite or indefinite-length
+       * Item count tracking is either for definite or indefinite-length
        * maps/arrays. For definite lengths, the total count and items
        * unconsumed are tracked. For indefinite-length, uTotalCount is
        * QCBOR_COUNT_INDICATES_INDEFINITE_LENGTH (UINT16_MAX) and
@@ -269,16 +269,16 @@ typedef struct __QCBORDecodeNesting  {
        * uCountCursor is QCBOR_COUNT_INDICATES_ZERO_LENGTH to indicate
        * it is empty.
        *
-       * This also records whether a level is bounded or not.  All
+       * This also records whether a level is bounded or not. All
        * byte-count tracked levels (the top-level sequence and
-       * bstr-wrapped CBOR) are bounded. Maps and arrays may or may
+       * bstr-wrapped CBOR) are bounded implicitly. Maps and arrays may or may
        * not be bounded. They are bounded if they were Entered() and
        * not if they were traversed with GetNext(). They are marked as
        * bounded by uStartOffset not being UINT32_MAX.
        */
       /*
        * If uLevelType can put in a separately indexed array, the
-       * union/ struct will be 8 bytes rather than 9 and a lot of
+       * union/struct will be 8 bytes rather than 9 and a lot of
        * wasted padding for alignment will be saved.
        */
       uint8_t  uLevelType;
@@ -289,6 +289,8 @@ typedef struct __QCBORDecodeNesting  {
             uint16_t uCountTotal;
             uint16_t uCountCursor;
 #define QCBOR_NON_BOUNDED_OFFSET UINT32_MAX
+            /* The start of the array or map in bounded mode so
+             * the input can be rewound for GetInMapXx() by label. */
             uint32_t uStartOffset;
          } ma; /* for maps and arrays */
          struct {

--- a/inc/qcbor/qcbor_spiffy_decode.h
+++ b/inc/qcbor/qcbor_spiffy_decode.h
@@ -91,9 +91,6 @@ extern "C" {
  * QCBORDecode_EnterArray() can be used to narrow the traversal to the
  * extent of the array.
  *
- * QCBORDecode_EnterArray() can be used to narrow the traversal to the
- * extent of the array.
- *
  * All the QCBORDecode_GetXxxxInMapX() methods support duplicate label
  * detection and will result in an error if the map has duplicate
  * labels.
@@ -701,7 +698,7 @@ QCBORDecode_EnterArrayFromMapSZ(QCBORDecodeContext *pMe, const char *szLabel);
  * The items in the array that was entered do not have to have been
  * consumed for this to succeed.
  *
- * This sets the pre-order traversal cursor to the item after the
+ * This sets the traversal cursor to the item after the
  * array that was exited.
  *
  * This will result in an error if any item in the array is not well
@@ -740,7 +737,7 @@ QCBORDecode_ExitArray(QCBORDecodeContext *pCtx);
  * fully exited.
  *
  * While in bounded mode, QCBORDecode_GetNext() works as usual on the
- * map and the pre-order traversal cursor is maintained. It starts out
+ * map and the traversal cursor is maintained. It starts out
  * at the first item in the map just entered. Attempts to get items
  * off the end of the map will give error @ref QCBOR_ERR_NO_MORE_ITEMS
  * rather going to the next item after the map as it would when not in
@@ -751,12 +748,12 @@ QCBORDecode_ExitArray(QCBORDecodeContext *pCtx);
  * non-aggregate items by label behaves differently from entering subordinate
  * aggregate items by label.  See dicussion in @ref SpiffyDecode.
  *
- * Exiting leaves the pre-order cursor at the data item following the
+ * Exiting leaves the traversal cursor at the data item following the
  * last entry in the map or at the end of the input CBOR if there
  * nothing after the map.
  *
  * Entering and Exiting a map is a way to skip over an entire map and
- * its contents. After QCBORDecode_ExitMap(), the pre-order traversal
+ * its contents. After QCBORDecode_ExitMap(), thetraversal
  * cursor will be at the first item after the map.
  *
  * Please see @ref Decode-Errors-Overview "Decode Errors Overview".
@@ -786,7 +783,7 @@ QCBORDecode_EnterMapFromMapSZ(QCBORDecodeContext *pCtx, const char *szLabel);
  * The items in the map that was entered do not have to have been
  * consumed for this to succeed.
  *
- * This sets the pre-order traversal cursor to the item after the map
+ * This sets the traversal cursor to the item after the map
  * that was exited.
  *
  * This will result in an error if any item in the map is not well
@@ -845,7 +842,7 @@ QCBORDecode_Rewind(QCBORDecodeContext *pCtx);
  * with little nesting, this is of little consequence, but may be of
  * consequence for large deeply nested CBOR structures on slow CPUs.
  *
- * The position of the pre-order traversal cursor is not changed.
+ * The position of the traversal cursor is not changed.
  *
  * Please see @ref Decode-Errors-Overview "Decode Errors Overview".
  *
@@ -892,7 +889,7 @@ QCBORDecode_GetItemInMapSZ(QCBORDecodeContext *pCtx,
  * QCBORDecode_EnterMapinMapN(), QCBORDecode_EnterArrayInMapN() and
  * such to descend into and process maps and arrays.
  *
- * The position of the pre-order traversal cursor is not changed.
+ * The position of the traversal cursor is not changed.
  *
  * Please see @ref Decode-Errors-Overview "Decode Errors Overview".
  *
@@ -1825,7 +1822,7 @@ QCBORDecode_EnterBstrWrappedFromMapSZ(QCBORDecodeContext *pCtx,
  * The items in the wrapped CBOR that was entered do not have to have
  * been consumed for this to succeed.
  *
- * The this sets the pre-order traversal cursor to the item after the
+ * The this sets the traversal cursor to the item after the
  * byte string that was exited.
  */
 void

--- a/inc/qcbor/qcbor_spiffy_decode.h
+++ b/inc/qcbor/qcbor_spiffy_decode.h
@@ -753,7 +753,7 @@ QCBORDecode_ExitArray(QCBORDecodeContext *pCtx);
  * nothing after the map.
  *
  * Entering and Exiting a map is a way to skip over an entire map and
- * its contents. After QCBORDecode_ExitMap(), thetraversal
+ * its contents. After QCBORDecode_ExitMap(), the traversal
  * cursor will be at the first item after the map.
  *
  * Please see @ref Decode-Errors-Overview "Decode Errors Overview".

--- a/src/qcbor_decode.c
+++ b/src/qcbor_decode.c
@@ -3132,6 +3132,31 @@ QCBORDecode_VGetNextConsume(QCBORDecodeContext *pMe, QCBORItem *pDecodedItem)
 }
 
 
+/*
+ * Public function, see header qcbor/qcbor_decode.h file
+ */
+uint32_t
+QCBORDecode_Tell(QCBORDecodeContext *pMe)
+{
+   size_t xx;
+
+   xx = (uint32_t)UsefulInputBuf_Tell(&(pMe->InBuf));
+
+   if(xx == UsefulInputBuf_GetBufferLength(&(pMe->InBuf))) {
+      return UINT32_MAX;
+   } else {
+      return (uint32_t)xx;
+   }
+
+   /*
+
+    Confirm position is as expected in maps and arrays for
+     - definite length
+     - indefinite lengths
+    */
+}
+
+
 /**
  * @brief Rewind cursor to start as if map or array were just entered.
  *
@@ -3262,6 +3287,7 @@ QCBORDecode_Private_MapSearch(QCBORDecodeContext *pMe,
    }
 
    QCBORDecodeNesting SaveNesting;
+   size_t uSavePos = UsefulInputBuf_Tell(&(pMe->InBuf));
    DecodeNesting_PrepareForMapSearch(&(pMe->nesting), &SaveNesting);
 
    /* Reposition to search from the start of the map / array */
@@ -3378,6 +3404,7 @@ QCBORDecode_Private_MapSearch(QCBORDecodeContext *pMe,
 
  Done:
    DecodeNesting_RestoreFromMapSearch(&(pMe->nesting), &SaveNesting);
+   UsefulInputBuf_Seek(&(pMe->InBuf), uSavePos);
 
  Done2:
    /* For all items not found, set the data and label type to QCBOR_TYPE_NONE */

--- a/src/qcbor_decode.c
+++ b/src/qcbor_decode.c
@@ -3138,22 +3138,20 @@ QCBORDecode_VGetNextConsume(QCBORDecodeContext *pMe, QCBORItem *pDecodedItem)
 uint32_t
 QCBORDecode_Tell(QCBORDecodeContext *pMe)
 {
-   size_t xx;
+   size_t uCursorOffset;
 
-   xx = (uint32_t)UsefulInputBuf_Tell(&(pMe->InBuf));
-
-   if(xx == UsefulInputBuf_GetBufferLength(&(pMe->InBuf))) {
+   if(pMe->uLastError != QCBOR_SUCCESS) {
       return UINT32_MAX;
-   } else {
-      return (uint32_t)xx;
    }
 
-   /*
+   uCursorOffset = UsefulInputBuf_Tell(&(pMe->InBuf));
 
-    Confirm position is as expected in maps and arrays for
-     - definite length
-     - indefinite lengths
-    */
+   if(uCursorOffset == UsefulInputBuf_GetBufferLength(&(pMe->InBuf))) {
+      return UINT32_MAX;
+   } else {
+      /* Cast is safe because decoder input size is restricted. */
+      return (uint32_t)uCursorOffset;
+   }
 }
 
 

--- a/src/qcbor_encode.c
+++ b/src/qcbor_encode.c
@@ -474,7 +474,7 @@ QCBOREncode_EncodeHead(UsefulBuf Buffer,
    /* This expression integer-promotes to type int. The code above in
     * function guarantees that nAdditionalInfo will never be larger
     * than 0x1f. The caller may pass in a too-large uMajor type. The
-    * conversion to unint8_t will cause an integer wrap around and
+    * conversion to uint8_t will cause an integer wrap around and
     * incorrect CBOR will be generated, but no security issue will
     * occur.
     */

--- a/test/qcbor_decode_tests.h
+++ b/test/qcbor_decode_tests.h
@@ -323,4 +323,7 @@ int32_t CBORTestIssue134(void);
 int32_t ErrorHandlingTests(void);
 
 
+int32_t TellTests(void);
+
+
 #endif /* defined(__QCBOR__qcbort_decode_tests__) */

--- a/test/run_tests.c
+++ b/test/run_tests.c
@@ -66,6 +66,7 @@ static test_entry2 s_tests2[] = {
 
 
 static test_entry s_tests[] = {
+    TEST_ENTRY(TellTests),
    TEST_ENTRY(ErrorHandlingTests),
    TEST_ENTRY(OpenCloseBytesTest),
     TEST_ENTRY(EnterBstrTest),

--- a/test/run_tests.c
+++ b/test/run_tests.c
@@ -1,7 +1,7 @@
 /*==============================================================================
  run_tests.c -- test aggregator and results reporting
 
- Copyright (c) 2018-2021, Laurence Lundblade. All rights reserved.
+ Copyright (c) 2018-2024, Laurence Lundblade. All rights reserved.
  Copyright (c) 2021, Arm Limited. All rights reserved.
 
  SPDX-License-Identifier: BSD-3-Clause
@@ -67,8 +67,8 @@ static test_entry2 s_tests2[] = {
 
 static test_entry s_tests[] = {
     TEST_ENTRY(TellTests),
-   TEST_ENTRY(ErrorHandlingTests),
-   TEST_ENTRY(OpenCloseBytesTest),
+    TEST_ENTRY(ErrorHandlingTests),
+    TEST_ENTRY(OpenCloseBytesTest),
     TEST_ENTRY(EnterBstrTest),
     TEST_ENTRY(IntegerConvertTest),
     TEST_ENTRY(EnterMapTest),


### PR DESCRIPTION
Adds QCBORDecode_Tell() to return traversal cursor position.

Fixes a traversal cursor position bug. The position was not correct after a Get() of a non-aggregate item by label (e.g., QCBORDecode_GetInt64InMapN()) in an array that was entered.

Fixes to documentation for traversal cursor.

Addresses #213 
