### PR TITLE
Fixes for maps-as-arrays mode and unusual map labels

### DIFF
--- a/inc/qcbor/qcbor_decode.h
+++ b/inc/qcbor/qcbor_decode.h
@@ -310,10 +310,10 @@ typedef enum {
 /** Type for the simple value undef. */
 #define QCBOR_TYPE_UNDEF         23
 
-/** Type for a floating-point number. Data is in @c val.float. */
+/** Type for a floating-point number. Data is in @c val.fnum. */
 #define QCBOR_TYPE_FLOAT         26
 
-/** Type for a double floating-point number. Data is in @c val.double. */
+/** Type for a double floating-point number. Data is in @c val.dfnum. */
 #define QCBOR_TYPE_DOUBLE        27
 
 #define QCBOR_TYPE_BREAK         31 /* Used internally; never returned */

--- a/src/qcbor_decode.c
+++ b/src/qcbor_decode.c
@@ -372,12 +372,12 @@ DecodeNesting_IsBoundedType(const QCBORDecodeNesting *pNesting, uint8_t uType)
       return false;
    }
 
-   uint8_t uT = pNesting->pCurrentBounded->uLevelType;
-   if(uT == QCBOR_TYPE_MAP_AS_ARRAY) {
-      uT = QCBOR_TYPE_ARRAY;
+   uint8_t uItemDataType = pNesting->pCurrentBounded->uLevelType;
+   if(uItemDataType == QCBOR_TYPE_MAP_AS_ARRAY) {
+      uItemDataType = QCBOR_TYPE_ARRAY;
    }
 
-   if(uT != uType) {
+   if(uItemDataType != uType) {
       return false;
    }
 
@@ -3579,12 +3579,12 @@ QCBORDecode_Private_GetArrayOrMap(QCBORDecodeContext *pMe,
       return;
    }
 
-   uint8_t uT = pItem->uDataType;
-   if(uT == QCBOR_TYPE_MAP_AS_ARRAY) {
-      uT = QCBOR_TYPE_ARRAY;
+   uint8_t uItemDataType = pItem->uDataType;
+   if(uItemDataType == QCBOR_TYPE_MAP_AS_ARRAY) {
+      uItemDataType = QCBOR_TYPE_ARRAY;
    }
 
-   if(uT != uType) {
+   if(uItemDataType != uType) {
       pMe->uLastError = QCBOR_ERR_UNEXPECTED_TYPE;
       return;
    }
@@ -4070,11 +4070,11 @@ QCBORDecode_Private_EnterBoundedMapOrArray(QCBORDecodeContext *pMe,
       goto Done;
    }
 
-   uint8_t uT = Item.uDataType;
-   if(uT == QCBOR_TYPE_MAP_AS_ARRAY ) {
-      uT = QCBOR_TYPE_ARRAY;
+   uint8_t uItemDataType = Item.uDataType;
+   if(uItemDataType == QCBOR_TYPE_MAP_AS_ARRAY ) {
+      uItemDataType = QCBOR_TYPE_ARRAY;
    }
-   if(uT != uType) {
+   if(uItemDataType != uType) {
       uErr = QCBOR_ERR_UNEXPECTED_TYPE;
       goto Done;
    }

--- a/test/qcbor_decode_tests.c
+++ b/test/qcbor_decode_tests.c
@@ -1098,7 +1098,7 @@ int32_t ShortBufferParseTest2(void)
 }
 
 
-/* This test requires indef strings, HW float and preferred float */
+/* This test requires indef strings, HW float and preferred float,... */
 #if !defined(QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS) && \
     !defined(QCBOR_DISABLE_FLOAT_HW_USE) && \
     !defined(QCBOR_DISABLE_PREFERRED_FLOAT) && \
@@ -1267,6 +1267,7 @@ static int32_t ParseMapTest1(QCBORDecodeMode nMode)
    return 0;
 }
 
+
 /* This test requires indef strings, HW float and preferred float,... */
 #if !defined(QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS) && \
     !defined(QCBOR_DISABLE_FLOAT_HW_USE) && \
@@ -1274,9 +1275,9 @@ static int32_t ParseMapTest1(QCBORDecodeMode nMode)
     !defined(QCBOR_DISABLE_TAGS) && \
     !defined(QCBOR_DISABLE_INDEFINITE_LENGTH_ARRAYS)
 
-/* Decode a one byte string and match to letter. */
+/* Utility to decode a one byte string and match to letter. */
 static QCBORError
-GetTextX(QCBORDecodeContext *pDecode, uint8_t letter)
+CheckOneLetterString(QCBORDecodeContext *pDecode, uint8_t letter)
 {
    UsefulBufC Text;
    QCBORError uErr;
@@ -1513,7 +1514,7 @@ int32_t ParseMapAsArrayTest(void)
       return -50;
    }
 
-/* This test requires indef strings, HW float and preferred float */
+   /* This test requires indef strings, HW float and preferred float,... */
 #if !defined(QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS) && \
     !defined(QCBOR_DISABLE_FLOAT_HW_USE) && \
     !defined(QCBOR_DISABLE_PREFERRED_FLOAT) && \
@@ -1932,19 +1933,19 @@ int32_t ParseMapAsArrayTest(void)
    bool b;
    QCBORDecode_GetBool(&DCtx, &b);
 
-   uErr = GetTextX(&DCtx, 'a');
+   uErr = CheckOneLetterString(&DCtx, 'a');
    if(uErr) {
       return MakeTestResultCode(11, 1, uErr);
    }
 
    QCBORDecode_GetNull(&DCtx);
-   uErr = GetTextX(&DCtx, 'b');
+   uErr = CheckOneLetterString(&DCtx, 'b');
    if(uErr) {
       return MakeTestResultCode(11, 2, uErr);
    }
 
    QCBORDecode_VGetNext(&DCtx,  &Item);
-   uErr = GetTextX(&DCtx, 'c');
+   uErr = CheckOneLetterString(&DCtx, 'c');
    if(uErr) {
       return MakeTestResultCode(11, 3, uErr);
    }
@@ -1954,7 +1955,7 @@ int32_t ParseMapAsArrayTest(void)
    if(!isnan(dNum)) {
       return MakeTestResultCode(11, 4, 0);
    }
-   uErr = GetTextX(&DCtx, 'd');
+   uErr = CheckOneLetterString(&DCtx, 'd');
    if(uErr) {
       return MakeTestResultCode(11, 5, uErr);
    }
@@ -1963,7 +1964,7 @@ int32_t ParseMapAsArrayTest(void)
    if( dNum != 3.4028234663852886E+38 ) {
       return MakeTestResultCode(11, 6, 0);
    }
-   uErr = GetTextX(&DCtx, 'e');
+   uErr = CheckOneLetterString(&DCtx, 'e');
    if(uErr) {
       return MakeTestResultCode(11, 7, uErr);
    }
@@ -1972,7 +1973,7 @@ int32_t ParseMapAsArrayTest(void)
    if(dNum != -INFINITY) {
       return MakeTestResultCode(11, 8, 0);
    }
-   uErr = GetTextX(&DCtx, 'f');
+   uErr = CheckOneLetterString(&DCtx, 'f');
    if(uErr) {
       return MakeTestResultCode(11, 9, uErr);
    }
@@ -1982,7 +1983,7 @@ int32_t ParseMapAsArrayTest(void)
    QCBORDecode_GetInt64(&DCtx, &nInt);
    QCBORDecode_GetInt64(&DCtx, &nInt);
    QCBORDecode_ExitArray(&DCtx);
-   uErr = GetTextX(&DCtx, 'g');
+   uErr = CheckOneLetterString(&DCtx, 'g');
    if(uErr) {
       return MakeTestResultCode(11, 10, uErr);
    }
@@ -1995,12 +1996,12 @@ int32_t ParseMapAsArrayTest(void)
    QCBORDecode_ExitArray(&DCtx);
    QCBORDecode_ExitArray(&DCtx);
    QCBORDecode_ExitArray(&DCtx);
-   uErr = GetTextX(&DCtx, 'h');
+   uErr = CheckOneLetterString(&DCtx, 'h');
    if(uErr) {
       return MakeTestResultCode(11, 11, uErr);
    }
    QCBORDecode_GetEpochDate(&DCtx, QCBOR_TAG_REQUIREMENT_TAG, &nInt);
-   uErr = GetTextX(&DCtx, 'i');
+   uErr = CheckOneLetterString(&DCtx, 'i');
    if(uErr) {
       return MakeTestResultCode(11, 12, uErr);
    }
@@ -2014,13 +2015,13 @@ int32_t ParseMapAsArrayTest(void)
    QCBORDecode_GetInt64(&DCtx, &nInt);
    QCBORDecode_ExitArray(&DCtx);
    QCBORDecode_ExitArray(&DCtx);
-   uErr = GetTextX(&DCtx, 'j');
+   uErr = CheckOneLetterString(&DCtx, 'j');
    if(uErr) {
       return MakeTestResultCode(11, 13, uErr);
    }
 
    QCBORDecode_GetArray(&DCtx, &Item, &Encoded);
-   uErr = GetTextX(&DCtx, 'k');
+   uErr = CheckOneLetterString(&DCtx, 'k');
    if(uErr) {
       return MakeTestResultCode(11, 14, uErr);
    }
@@ -2030,13 +2031,13 @@ int32_t ParseMapAsArrayTest(void)
    QCBORDecode_GetInt64(&DCtx, &nInt);
    QCBORDecode_GetInt64(&DCtx, &nInt);
    QCBORDecode_ExitArray(&DCtx);
-   uErr = GetTextX(&DCtx, 'l');
+   uErr = CheckOneLetterString(&DCtx, 'l');
    if(uErr) {
       return MakeTestResultCode(11, 15, uErr);
    }
 
    QCBORDecode_GetTextString(&DCtx, &Encoded);
-   uErr = GetTextX(&DCtx, 'm');
+   uErr = CheckOneLetterString(&DCtx, 'm');
    if(uErr) {
       return MakeTestResultCode(11, 16, uErr);
    }
@@ -2071,7 +2072,7 @@ int32_t ParseMapAsArrayTest(void)
    }
    QCBORDecode_ExitArray(&DCtx);
    QCBORDecode_ExitArray(&DCtx);
-   uErr = GetTextX(&DCtx, 'n');
+   uErr = CheckOneLetterString(&DCtx, 'n');
    if(uErr) {
       return MakeTestResultCode(11, 25, uErr);
    }

--- a/test/qcbor_decode_tests.c
+++ b/test/qcbor_decode_tests.c
@@ -1098,7 +1098,13 @@ int32_t ShortBufferParseTest2(void)
 }
 
 
-#ifndef QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS
+/* This test requires indef strings, HW float and preferred float */
+#if !defined(QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS) && \
+    !defined(QCBOR_DISABLE_FLOAT_HW_USE) && \
+    !defined(QCBOR_DISABLE_PREFERRED_FLOAT) && \
+    !defined(QCBOR_DISABLE_TAGS) && \
+    !defined(QCBOR_DISABLE_INDEFINITE_LENGTH_ARRAYS)
+
 static const uint8_t pPerverseLabels[] = {
    0xae,
 
@@ -1130,7 +1136,7 @@ static const uint8_t pPerverseLabels[] = {
 
    0xd9, 0x01, 0x02, 0xbf, 0x7f, 0x61, 0x4a, 0x61, 0x4b, 0xff, 0x00, 0xf4, 0xd7, 0x80 ,0xff, 0x61, 0x6e
 };
-#endif /* !QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS */
+#endif
 
 
 /*
@@ -1261,8 +1267,14 @@ static int32_t ParseMapTest1(QCBORDecodeMode nMode)
    return 0;
 }
 
+/* This test requires indef strings, HW float and preferred float,... */
+#if !defined(QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS) && \
+    !defined(QCBOR_DISABLE_FLOAT_HW_USE) && \
+    !defined(QCBOR_DISABLE_PREFERRED_FLOAT) && \
+    !defined(QCBOR_DISABLE_TAGS) && \
+    !defined(QCBOR_DISABLE_INDEFINITE_LENGTH_ARRAYS)
 
-#ifndef QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS
+/* Decode a one byte string and match to letter. */
 static QCBORError
 GetTextX(QCBORDecodeContext *pDecode, uint8_t letter)
 {
@@ -1285,7 +1297,7 @@ GetTextX(QCBORDecodeContext *pDecode, uint8_t letter)
 
    return QCBOR_SUCCESS;
 }
-#endif /* !QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS */
+#endif
 
 
 /*
@@ -1501,7 +1513,13 @@ int32_t ParseMapAsArrayTest(void)
       return -50;
    }
 
-#ifndef QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS
+/* This test requires indef strings, HW float and preferred float */
+#if !defined(QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS) && \
+    !defined(QCBOR_DISABLE_FLOAT_HW_USE) && \
+    !defined(QCBOR_DISABLE_PREFERRED_FLOAT) && \
+    !defined(QCBOR_DISABLE_TAGS) && \
+    !defined(QCBOR_DISABLE_INDEFINITE_LENGTH_ARRAYS)
+
    UsefulBufC         Encoded;
 
    /* Big decode of a map with a wide variety or labels */
@@ -2063,7 +2081,7 @@ int32_t ParseMapAsArrayTest(void)
    if(uErr) {
       return MakeTestResultCode(11, 26, uErr);
    }
-#endif /* QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS */
+#endif /* QCBOR_DISABLE_... */
 
    return 0;
 }

--- a/test/qcbor_decode_tests.c
+++ b/test/qcbor_decode_tests.c
@@ -1098,6 +1098,7 @@ int32_t ShortBufferParseTest2(void)
 }
 
 
+#ifndef QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS
 static const uint8_t pPerverseLabels[] = {
    0xae,
 
@@ -1129,6 +1130,7 @@ static const uint8_t pPerverseLabels[] = {
 
    0xd9, 0x01, 0x02, 0xbf, 0x7f, 0x61, 0x4a, 0x61, 0x4b, 0xff, 0x00, 0xf4, 0xd7, 0x80 ,0xff, 0x61, 0x6e
 };
+#endif /* !QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS */
 
 
 /*
@@ -1260,6 +1262,7 @@ static int32_t ParseMapTest1(QCBORDecodeMode nMode)
 }
 
 
+#ifndef QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS
 static QCBORError
 GetTextX(QCBORDecodeContext *pDecode, uint8_t letter)
 {
@@ -1276,13 +1279,13 @@ GetTextX(QCBORDecodeContext *pDecode, uint8_t letter)
       return QCBOR_ERR_FIRST_USER_DEFINED;
    }
 
-   if(*(uint8_t *)Text.ptr != letter) {
+   if(*(const uint8_t *)Text.ptr != letter) {
       return QCBOR_ERR_FIRST_USER_DEFINED;
    }
 
    return QCBOR_SUCCESS;
-
 }
+#endif /* !QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS */
 
 
 /*
@@ -1292,15 +1295,15 @@ GetTextX(QCBORDecodeContext *pDecode, uint8_t letter)
 int32_t ParseMapAsArrayTest(void)
 {
    QCBORDecodeContext DCtx;
-   QCBORItem Item;
-   QCBORError uErr;
+   QCBORItem          Item;
+   QCBORError         uErr;
 
    QCBORDecode_Init(&DCtx,
                     UsefulBuf_FROM_BYTE_ARRAY_LITERAL(pValidMapEncoded),
                     QCBOR_DECODE_MODE_MAP_AS_ARRAY);
 
    if((uErr = QCBORDecode_GetNext(&DCtx, &Item))) {
-      return (int32_t)uErr;
+      return MakeTestResultCode(1, 1, uErr);
    }
    if(Item.uDataType != QCBOR_TYPE_MAP_AS_ARRAY ||
       Item.val.uCount != 6) {
@@ -1498,15 +1501,15 @@ int32_t ParseMapAsArrayTest(void)
       return -50;
    }
 
+#ifndef QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS
+   UsefulBufC         Encoded;
 
    /* Big decode of a map with a wide variety or labels */
    QCBORDecode_Init(&DCtx,
                     UsefulBuf_FROM_BYTE_ARRAY_LITERAL(pPerverseLabels),
                     QCBOR_DECODE_MODE_MAP_AS_ARRAY);
-#ifndef QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS
       UsefulBuf_MAKE_STACK_UB(Pool, 100);
       QCBORDecode_SetMemPool(&DCtx, Pool, 0);
-#endif /* QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS */
 
    uErr = QCBORDecode_GetNext(&DCtx, &Item);
    if(uErr) {
@@ -1532,10 +1535,9 @@ int32_t ParseMapAsArrayTest(void)
    }
    if(Item.uLabelType != QCBOR_TYPE_NONE ||
       Item.uDataType != QCBOR_TYPE_TEXT_STRING ||
-      ((char *)Item.val.string.ptr)[0] != 'a') {
+      ((const char *)Item.val.string.ptr)[0] != 'a') {
       return MakeTestResultCode(10, 6, 0);
    }
-
 
    uErr = QCBORDecode_GetNext(&DCtx, &Item);
    if(uErr) {
@@ -1552,10 +1554,9 @@ int32_t ParseMapAsArrayTest(void)
    }
    if(Item.uLabelType != QCBOR_TYPE_NONE ||
       Item.uDataType != QCBOR_TYPE_TEXT_STRING ||
-      ((char *)Item.val.string.ptr)[0] != 'b') {
+      ((const char *)Item.val.string.ptr)[0] != 'b') {
       return MakeTestResultCode(10, 10, 0);
    }
-
 
    uErr = QCBORDecode_GetNext(&DCtx, &Item);
    if(uErr) {
@@ -1573,10 +1574,9 @@ int32_t ParseMapAsArrayTest(void)
    }
    if(Item.uLabelType != QCBOR_TYPE_NONE ||
       Item.uDataType != QCBOR_TYPE_TEXT_STRING ||
-      ((char *)Item.val.string.ptr)[0] != 'c') {
+      ((const char *)Item.val.string.ptr)[0] != 'c') {
       return MakeTestResultCode(10, 14, 0);
    }
-
 
    uErr = QCBORDecode_GetNext(&DCtx, &Item);
    if(uErr) {
@@ -1594,7 +1594,7 @@ int32_t ParseMapAsArrayTest(void)
    }
    if(Item.uLabelType != QCBOR_TYPE_NONE ||
       Item.uDataType != QCBOR_TYPE_TEXT_STRING ||
-      ((char *)Item.val.string.ptr)[0] != 'd') {
+      ((const char *)Item.val.string.ptr)[0] != 'd') {
       return MakeTestResultCode(10, 18, 0);
    }
 
@@ -1615,7 +1615,7 @@ int32_t ParseMapAsArrayTest(void)
    }
    if(Item.uLabelType != QCBOR_TYPE_NONE ||
       Item.uDataType != QCBOR_TYPE_TEXT_STRING ||
-      ((char *)Item.val.string.ptr)[0] != 'e') {
+      ((const char *)Item.val.string.ptr)[0] != 'e') {
       return MakeTestResultCode(10, 22, 0);
    }
 
@@ -1635,10 +1635,9 @@ int32_t ParseMapAsArrayTest(void)
    }
    if(Item.uLabelType != QCBOR_TYPE_NONE ||
       Item.uDataType != QCBOR_TYPE_TEXT_STRING ||
-      ((char *)Item.val.string.ptr)[0] != 'f') {
+      ((const char *)Item.val.string.ptr)[0] != 'f') {
       return MakeTestResultCode(10, 26, 0);
    }
-
 
    uErr = QCBORDecode_GetNext(&DCtx, &Item);
    if(uErr) {
@@ -1676,10 +1675,9 @@ int32_t ParseMapAsArrayTest(void)
    }
    if(Item.uLabelType != QCBOR_TYPE_NONE ||
       Item.uDataType != QCBOR_TYPE_TEXT_STRING ||
-      ((char *)Item.val.string.ptr)[0] != 'g') {
+      ((const char *)Item.val.string.ptr)[0] != 'g') {
       return MakeTestResultCode(10, 33, 0);
    }
-
 
    for(int i = 0 ; i < 4; i++) {
       uErr = QCBORDecode_GetNext(&DCtx, &Item);
@@ -1696,17 +1694,15 @@ int32_t ParseMapAsArrayTest(void)
          }
       }
    }
-
    uErr = QCBORDecode_GetNext(&DCtx, &Item);
    if(uErr) {
       return MakeTestResultCode(10, 36, uErr);
    }
    if(Item.uLabelType != QCBOR_TYPE_NONE ||
       Item.uDataType != QCBOR_TYPE_TEXT_STRING ||
-      ((char *)Item.val.string.ptr)[0] != 'h') {
+      ((const char *)Item.val.string.ptr)[0] != 'h') {
       return MakeTestResultCode(10, 37, 0);
    }
-
 
    uErr = QCBORDecode_GetNext(&DCtx, &Item);
    if(uErr) {
@@ -1723,11 +1719,9 @@ int32_t ParseMapAsArrayTest(void)
    }
    if(Item.uLabelType != QCBOR_TYPE_NONE ||
       Item.uDataType != QCBOR_TYPE_TEXT_STRING ||
-      ((char *)Item.val.string.ptr)[0] != 'i') {
+      ((const char *)Item.val.string.ptr)[0] != 'i') {
       return MakeTestResultCode(10, 41, 0);
    }
-
-
 
    uErr = QCBORDecode_GetNext(&DCtx, &Item);
    if(uErr) {
@@ -1768,14 +1762,13 @@ int32_t ParseMapAsArrayTest(void)
          return MakeTestResultCode(10, 47, 0);
       }
    }
-
    uErr = QCBORDecode_GetNext(&DCtx, &Item);
    if(uErr) {
       return MakeTestResultCode(10, 48, uErr);
    }
    if(Item.uLabelType != QCBOR_TYPE_NONE ||
       Item.uDataType != QCBOR_TYPE_TEXT_STRING ||
-      ((char *)Item.val.string.ptr)[0] != 'j') {
+      ((const char *)Item.val.string.ptr)[0] != 'j') {
       return MakeTestResultCode(10, 49, 0);
    }
 
@@ -1795,10 +1788,9 @@ int32_t ParseMapAsArrayTest(void)
    }
    if(Item.uLabelType != QCBOR_TYPE_NONE ||
       Item.uDataType != QCBOR_TYPE_TEXT_STRING ||
-      ((char *)Item.val.string.ptr)[0] != 'k') {
+      ((const char *)Item.val.string.ptr)[0] != 'k') {
       return MakeTestResultCode(10, 53, 0);
    }
-
 
    uErr = QCBORDecode_GetNext(&DCtx, &Item);
    if(uErr) {
@@ -1820,17 +1812,15 @@ int32_t ParseMapAsArrayTest(void)
          return MakeTestResultCode(10, 57, 0);
       }
    }
-
    uErr = QCBORDecode_GetNext(&DCtx, &Item);
    if(uErr) {
       return MakeTestResultCode(10, 58, uErr);
    }
    if(Item.uLabelType != QCBOR_TYPE_NONE ||
       Item.uDataType != QCBOR_TYPE_TEXT_STRING ||
-      ((char *)Item.val.string.ptr)[0] != 'l') {
+      ((const char *)Item.val.string.ptr)[0] != 'l') {
       return MakeTestResultCode(10, 59, 0);
    }
-
 
    uErr = QCBORDecode_GetNext(&DCtx, &Item);
    if(uErr) {
@@ -1848,10 +1838,9 @@ int32_t ParseMapAsArrayTest(void)
    }
    if(Item.uLabelType != QCBOR_TYPE_NONE ||
       Item.uDataType != QCBOR_TYPE_TEXT_STRING ||
-      ((char *)Item.val.string.ptr)[0] != 'm') {
+      ((const char *)Item.val.string.ptr)[0] != 'm') {
       return MakeTestResultCode(10, 63, 0);
    }
-
 
    uErr = QCBORDecode_GetNext(&DCtx, &Item);
    if(uErr) {
@@ -1910,7 +1899,7 @@ int32_t ParseMapAsArrayTest(void)
    }
    if(Item.uLabelType != QCBOR_TYPE_NONE ||
       Item.uDataType != QCBOR_TYPE_TEXT_STRING ||
-      ((char *)Item.val.string.ptr)[0] != 'n') {
+      ((const char *)Item.val.string.ptr)[0] != 'n') {
       return MakeTestResultCode(10, 75, 0);
    }
 
@@ -1919,9 +1908,7 @@ int32_t ParseMapAsArrayTest(void)
    QCBORDecode_Init(&DCtx,
                     UsefulBuf_FROM_BYTE_ARRAY_LITERAL(pPerverseLabels),
                     QCBOR_DECODE_MODE_MAP_AS_ARRAY);
-#ifndef QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS
       QCBORDecode_SetMemPool(&DCtx, Pool, 0);
-#endif /* QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS */
 
    QCBORDecode_EnterArray(&DCtx, &Item);
    bool b;
@@ -1929,21 +1916,20 @@ int32_t ParseMapAsArrayTest(void)
 
    uErr = GetTextX(&DCtx, 'a');
    if(uErr) {
-      return MakeTestResultCode(11, 4, uErr);
+      return MakeTestResultCode(11, 1, uErr);
    }
 
    QCBORDecode_GetNull(&DCtx);
    uErr = GetTextX(&DCtx, 'b');
    if(uErr) {
-      return MakeTestResultCode(11, 4, uErr);
+      return MakeTestResultCode(11, 2, uErr);
    }
 
    QCBORDecode_VGetNext(&DCtx,  &Item);
    uErr = GetTextX(&DCtx, 'c');
    if(uErr) {
-      return MakeTestResultCode(11, 4, uErr);
+      return MakeTestResultCode(11, 3, uErr);
    }
-
 
    double dNum;
    QCBORDecode_GetDouble(&DCtx, &dNum);
@@ -1952,25 +1938,25 @@ int32_t ParseMapAsArrayTest(void)
    }
    uErr = GetTextX(&DCtx, 'd');
    if(uErr) {
-      return MakeTestResultCode(11, 4, uErr);
+      return MakeTestResultCode(11, 5, uErr);
    }
 
    QCBORDecode_GetDouble(&DCtx, &dNum);
    if( dNum != 3.4028234663852886E+38 ) {
-      return MakeTestResultCode(11, 4, 0);
+      return MakeTestResultCode(11, 6, 0);
    }
    uErr = GetTextX(&DCtx, 'e');
    if(uErr) {
-      return MakeTestResultCode(11, 4, uErr);
+      return MakeTestResultCode(11, 7, uErr);
    }
 
    QCBORDecode_GetDouble(&DCtx, &dNum);
    if(dNum != -INFINITY) {
-      return MakeTestResultCode(11, 4, 0);
+      return MakeTestResultCode(11, 8, 0);
    }
    uErr = GetTextX(&DCtx, 'f');
    if(uErr) {
-      return MakeTestResultCode(11, 4, uErr);
+      return MakeTestResultCode(11, 9, uErr);
    }
 
    int64_t nInt;
@@ -1980,9 +1966,8 @@ int32_t ParseMapAsArrayTest(void)
    QCBORDecode_ExitArray(&DCtx);
    uErr = GetTextX(&DCtx, 'g');
    if(uErr) {
-      return MakeTestResultCode(11, 4, uErr);
+      return MakeTestResultCode(11, 10, uErr);
    }
-
 
    QCBORDecode_EnterArray(&DCtx, &Item);
    QCBORDecode_EnterArray(&DCtx, &Item);
@@ -1994,12 +1979,12 @@ int32_t ParseMapAsArrayTest(void)
    QCBORDecode_ExitArray(&DCtx);
    uErr = GetTextX(&DCtx, 'h');
    if(uErr) {
-      return MakeTestResultCode(11, 4, uErr);
+      return MakeTestResultCode(11, 11, uErr);
    }
    QCBORDecode_GetEpochDate(&DCtx, QCBOR_TAG_REQUIREMENT_TAG, &nInt);
    uErr = GetTextX(&DCtx, 'i');
    if(uErr) {
-      return MakeTestResultCode(11, 4, uErr);
+      return MakeTestResultCode(11, 12, uErr);
    }
 
    QCBORDecode_EnterArray(&DCtx, &Item);
@@ -2013,15 +1998,13 @@ int32_t ParseMapAsArrayTest(void)
    QCBORDecode_ExitArray(&DCtx);
    uErr = GetTextX(&DCtx, 'j');
    if(uErr) {
-      return MakeTestResultCode(11, 4, uErr);
+      return MakeTestResultCode(11, 13, uErr);
    }
-
-   UsefulBufC Encoded;
 
    QCBORDecode_GetArray(&DCtx, &Item, &Encoded);
    uErr = GetTextX(&DCtx, 'k');
    if(uErr) {
-      return MakeTestResultCode(11, 4, uErr);
+      return MakeTestResultCode(11, 14, uErr);
    }
 
    QCBORDecode_EnterArray(&DCtx, &Item);
@@ -2031,57 +2014,61 @@ int32_t ParseMapAsArrayTest(void)
    QCBORDecode_ExitArray(&DCtx);
    uErr = GetTextX(&DCtx, 'l');
    if(uErr) {
-      return MakeTestResultCode(11, 4, uErr);
+      return MakeTestResultCode(11, 15, uErr);
    }
 
    QCBORDecode_GetTextString(&DCtx, &Encoded);
    uErr = GetTextX(&DCtx, 'm');
    if(uErr) {
-      return MakeTestResultCode(11, 4, uErr);
+      return MakeTestResultCode(11, 16, uErr);
    }
-
 
    QCBORDecode_EnterArray(&DCtx, &Item);
    if(!QCBORDecode_IsTagged(&DCtx, &Item, 258)) {
-      return MakeTestResultCode(11, 4, 0);
+      return MakeTestResultCode(11, 17, 0);
    }
    if(Item.uDataType != QCBOR_TYPE_MAP_AS_ARRAY) {
-      return MakeTestResultCode(11, 4, 0);
+      return MakeTestResultCode(11, 18, 0);
    }
    if(Item.val.uCount != UINT16_MAX) {
-      return MakeTestResultCode(11, 4, 0);
+      return MakeTestResultCode(11, 19, 0);
    }
    QCBORDecode_GetTextString(&DCtx, &Encoded);
    if(Encoded.len != 2) {
-      return MakeTestResultCode(11, 4, 0);
+      return MakeTestResultCode(11, 20, 0);
    }   QCBORDecode_GetInt64(&DCtx, &nInt);
    QCBORDecode_GetBool(&DCtx, &b);
    if(b != false) {
-      return MakeTestResultCode(11, 4, 0);
+      return MakeTestResultCode(11, 21, 0);
    }
    QCBORDecode_EnterArray(&DCtx, &Item);
    if(!QCBORDecode_IsTagged(&DCtx, &Item, 23)) {
-      return MakeTestResultCode(11, 4, 0);
+      return MakeTestResultCode(11, 22, 0);
    }
    if(Item.uDataType != QCBOR_TYPE_ARRAY) {
-      return MakeTestResultCode(11, 4, 0);
+      return MakeTestResultCode(11, 23, 0);
    }
    if(Item.val.uCount != 0) {
-      return MakeTestResultCode(11, 4, 0);
+      return MakeTestResultCode(11, 24, 0);
    }
    QCBORDecode_ExitArray(&DCtx);
    QCBORDecode_ExitArray(&DCtx);
    uErr = GetTextX(&DCtx, 'n');
    if(uErr) {
-      return MakeTestResultCode(11, 4, uErr);
+      return MakeTestResultCode(11, 25, uErr);
    }
+
    QCBORDecode_ExitArray(&DCtx);
    uErr = QCBORDecode_Finish(&DCtx);
    if(uErr) {
-      return MakeTestResultCode(11, 4, uErr);
+      return MakeTestResultCode(11, 26, uErr);
    }
+#endif /* QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS */
+
    return 0;
 }
+
+
 
 
 /*


### PR DESCRIPTION
bug fix: QCBOR_DECODE_MODE_MAP_AS_ARRAY didn't work with indefinite-length maps

bug fix: QCBOR_DECODE_MODE_MAP_AS_ARRAY didn't work with QCBORDecode_EnterArray() and QCBORDecode_GetArray().

Add lots of testing for QCBOR_DECODE_MODE_MAP_AS_ARRAY including testing with unusual map labels like NaN floating point, maps, tag data items.