### PR TITLE
Add EndCheck(); change QCBORDecode_Tell() behavior

### DIFF
--- a/inc/qcbor/qcbor_decode.h
+++ b/inc/qcbor/qcbor_decode.h
@@ -1096,9 +1096,9 @@ QCBORDecode_Tell(QCBORDecodeContext *pCtx);
  *
  * @returns Error code possibly indicating end of input.
  *
- * This returns the same as QCBORDecode_GetError() except that @ref
- * QCBOR_ERR_NO_MORE_ITEMS is returned if the travseral cursor is at
- * the end of the input.
+ * This returns the same as QCBORDecode_GetError() except that
+ * @ref QCBOR_ERR_NO_MORE_ITEMS is returned if the travseral cursor
+ * is at the end of the input.
  */
 QCBORError
 QCBORDecode_EndCheck(QCBORDecodeContext *pCtx);

--- a/inc/qcbor/qcbor_decode.h
+++ b/inc/qcbor/qcbor_decode.h
@@ -1096,9 +1096,10 @@ QCBORDecode_Tell(QCBORDecodeContext *pCtx);
  *
  * @returns Error code possibly indicating end of input.
  *
- * This returns the same as QCBORDecode_GetError() except that
- * @ref QCBOR_ERR_NO_MORE_ITEMS is returned if the travseral cursor
- * is at the end of the input.
+ * This returns the same as QCBORDecode_GetError() except that @ref
+ * QCBOR_ERR_NO_MORE_ITEMS is returned if the travseral cursor is at
+ * the end of the CBOR input bytes (not the end of an entered array or
+ * map).
  */
 QCBORError
 QCBORDecode_EndCheck(QCBORDecodeContext *pCtx);

--- a/src/qcbor_decode.c
+++ b/src/qcbor_decode.c
@@ -3161,23 +3161,22 @@ QCBORDecode_VGetNextConsume(QCBORDecodeContext *pMe, QCBORItem *pDecodedItem)
 /*
  * Public function, see header qcbor/qcbor_decode.h file
  */
-uint32_t
-QCBORDecode_Tell(QCBORDecodeContext *pMe)
+QCBORError
+QCBORDecode_EndCheck(QCBORDecodeContext *pMe)
 {
    size_t uCursorOffset;
 
    if(pMe->uLastError != QCBOR_SUCCESS) {
-      return UINT32_MAX;
+      return pMe->uLastError;
    }
 
    uCursorOffset = UsefulInputBuf_Tell(&(pMe->InBuf));
 
    if(uCursorOffset == UsefulInputBuf_GetBufferLength(&(pMe->InBuf))) {
-      return UINT32_MAX;
-   } else {
-      /* Cast is safe because decoder input size is restricted. */
-      return (uint32_t)uCursorOffset;
+      return QCBOR_ERR_NO_MORE_ITEMS;
    }
+
+   return QCBOR_SUCCESS;
 }
 
 

--- a/src/qcbor_decode.c
+++ b/src/qcbor_decode.c
@@ -3164,10 +3164,12 @@ QCBORDecode_VGetNextConsume(QCBORDecodeContext *pMe, QCBORItem *pDecodedItem)
 QCBORError
 QCBORDecode_EndCheck(QCBORDecodeContext *pMe)
 {
-   size_t uCursorOffset;
+   size_t     uCursorOffset;
+   QCBORError uErr;
 
-   if(pMe->uLastError != QCBOR_SUCCESS) {
-      return pMe->uLastError;
+   uErr = QCBORDecode_GetError(pMe);
+   if(uErr != QCBOR_SUCCESS) {
+      return uErr;
    }
 
    uCursorOffset = UsefulInputBuf_Tell(&(pMe->InBuf));

--- a/test/qcbor_decode_tests.c
+++ b/test/qcbor_decode_tests.c
@@ -9913,7 +9913,7 @@ int32_t TellTests(void)
    int64_t            nDecodedInt;
 
    static const uint32_t aPos[] =
-       {0, 1, 17, 42, 50, 58, 72, 85, 98, 112, UINT32_MAX};
+       {0, 1, 17, 42, 50, 58, 72, 85, 98, 112, 151};
    QCBORDecode_Init(&DCtx,
                     UsefulBuf_FROM_BYTE_ARRAY_LITERAL(pValidMapEncoded),
                     0);
@@ -9923,7 +9923,7 @@ int32_t TellTests(void)
          return nIndex;
       }
 
-      if(uPosition == UINT32_MAX) {
+      if(QCBORDecode_EndCheck(&DCtx)) {
          break;
       }
 
@@ -9932,7 +9932,7 @@ int32_t TellTests(void)
 
 #ifndef QCBOR_DISABLE_INDEFINITE_LENGTH_ARRAYS
    static const uint32_t aPosIndef[] =
-       {0, 1, 17, 42, 50, 59, 73, 86, 99, 113, UINT32_MAX};
+       {0, 1, 17, 42, 50, 59, 73, 86, 99, 113, 154};
    QCBORDecode_Init(&DCtx,
                     UsefulBuf_FROM_BYTE_ARRAY_LITERAL(pValidMapIndefEncoded),
                     0);
@@ -9943,7 +9943,7 @@ int32_t TellTests(void)
          return nIndex + 100;
       }
 
-      if(uPosition == UINT32_MAX) {
+      if(QCBORDecode_EndCheck(&DCtx)) {
          break;
       }
 
@@ -9990,7 +9990,7 @@ int32_t TellTests(void)
    }
 
    QCBORDecode_ExitMap(&DCtx);
-   if(QCBORDecode_Tell(&DCtx) != UINT32_MAX) {
+   if(QCBORDecode_Tell(&DCtx) != 151) {
       return 1009;
    }
    if(QCBORDecode_GetNext(&DCtx, &Item) != QCBOR_ERR_NO_MORE_ITEMS) {
@@ -10037,7 +10037,7 @@ int32_t TellTests(void)
    }
 
    QCBORDecode_ExitMap(&DCtx);
-   if(QCBORDecode_Tell(&DCtx) != UINT32_MAX) {
+   if(QCBORDecode_Tell(&DCtx) != 154) {
       return 2008;
    }
    if(QCBORDecode_GetNext(&DCtx, &Item) != QCBOR_ERR_NO_MORE_ITEMS) {
@@ -10056,6 +10056,10 @@ int32_t TellTests(void)
    if(QCBORDecode_Tell(&DCtx) != UINT32_MAX) {
       return 3000;
    }
+   if(QCBORDecode_EndCheck(&DCtx) != QCBOR_ERR_MAP_NOT_ENTERED) {
+      return 3001;
+   }
+
 
    /* Empties tests */
    const uint8_t pMinimalCBOR[] = {0xa0}; // One empty map
@@ -10063,19 +10067,25 @@ int32_t TellTests(void)
    if(QCBORDecode_Tell(&DCtx) != 0) {
       return 4000;
    }
+   if(QCBORDecode_EndCheck(&DCtx) != QCBOR_SUCCESS) {
+      return 4008;
+   }
    QCBORDecode_EnterMap(&DCtx, &Item);
    if(QCBORDecode_GetError(&DCtx) != QCBOR_SUCCESS) {
       return 4001;
    }
-   if(QCBORDecode_Tell(&DCtx) != UINT32_MAX) {
+   if(QCBORDecode_Tell(&DCtx) != 1) {
       return 4002;
    }
    QCBORDecode_ExitMap(&DCtx);
    if(QCBORDecode_GetError(&DCtx) != QCBOR_SUCCESS) {
-      return 4001;
+      return 4003;
    }
-   if(QCBORDecode_Tell(&DCtx) != UINT32_MAX) {
-      return 4002;
+   if(QCBORDecode_Tell(&DCtx) != 1) {
+      return 4004;
+   }
+   if(QCBORDecode_EndCheck(&DCtx) != QCBOR_ERR_NO_MORE_ITEMS) {
+      return 4005;
    }
    if(QCBORDecode_GetNext(&DCtx, &Item) != QCBOR_ERR_NO_MORE_ITEMS) {
       return 4010;
@@ -10091,15 +10101,18 @@ int32_t TellTests(void)
    if(QCBORDecode_GetError(&DCtx) != QCBOR_SUCCESS) {
       return 4101;
    }
-   if(QCBORDecode_Tell(&DCtx) != UINT32_MAX) {
+   if(QCBORDecode_Tell(&DCtx) != 2) {
       return 4102;
    }
    QCBORDecode_ExitMap(&DCtx);
    if(QCBORDecode_GetError(&DCtx) != QCBOR_SUCCESS) {
-      return 4101;
+      return 4103;
    }
-   if(QCBORDecode_Tell(&DCtx) != UINT32_MAX) {
-      return 4102;
+   if(QCBORDecode_Tell(&DCtx) != 2) {
+      return 4104;
+   }
+   if(QCBORDecode_EndCheck(&DCtx) != QCBOR_ERR_NO_MORE_ITEMS) {
+      return 4005;
    }
    if(QCBORDecode_GetNext(&DCtx, &Item) != QCBOR_ERR_NO_MORE_ITEMS) {
       return 4110;
@@ -10136,7 +10149,7 @@ int32_t TellTests(void)
    if(QCBORDecode_GetError(&DCtx) != QCBOR_SUCCESS) {
       return 5007;
    }
-   if(QCBORDecode_Tell(&DCtx) != UINT32_MAX) {
+   if(QCBORDecode_Tell(&DCtx) != 20) {
       return 5008;
    }
    if(QCBORDecode_GetNext(&DCtx, &Item) != QCBOR_ERR_NO_MORE_ITEMS) {
@@ -10171,7 +10184,7 @@ int32_t TellTests(void)
    }
 
    static const uint32_t aEmptiesPos[] =
-       {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 13, UINT32_MAX};
+       {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 13, 15};
    QCBORDecode_Init(&DCtx,
                     UsefulBuf_FROM_BYTE_ARRAY_LITERAL(sEmpties),
                     0);
@@ -10181,7 +10194,7 @@ int32_t TellTests(void)
          return nIndex + 200;
       }
 
-      if(uPosition == UINT32_MAX) {
+      if(QCBORDecode_EndCheck(&DCtx)) {
          break;
       }
 
@@ -10190,7 +10203,7 @@ int32_t TellTests(void)
 
 #ifndef QCBOR_DISABLE_INDEFINITE_LENGTH_ARRAYS
    static const uint32_t aIndefEmptiesPos[] =
-       {0, 1, 2, 4, 5, 7, 8, 10, 12, 13, 16, 19, UINT32_MAX};
+       {0, 1, 2, 4, 5, 7, 8, 10, 12, 13, 16, 19, 25};
    QCBORDecode_Init(&DCtx,
                     UsefulBuf_FROM_BYTE_ARRAY_LITERAL(sEmptiesIndef),
                     0);
@@ -10200,7 +10213,7 @@ int32_t TellTests(void)
          return nIndex + 300;
       }
 
-      if(uPosition == UINT32_MAX) {
+      if(QCBORDecode_EndCheck(&DCtx)) {
          break;
       }
 


### PR DESCRIPTION
QCBORDecode_Tell() returns the offset when at the end of the input rather than UINT32_MAX. This is a non-compatible change, but QCBORDecode_Tell() was very recently introduced and is not present in any official releases.

QCBORDecode_EndCheck() is added to check to see if the cursor is at the end of the input.

Addresses #230