### PR TITLE
Remove unneeded v1 compat mode from encode

### DIFF
--- a/inc/qcbor/qcbor_encode.h
+++ b/inc/qcbor/qcbor_encode.h
@@ -633,13 +633,6 @@ static void
 QCBOREncode_Allow(QCBOREncodeContext *pCtx, uint8_t uAllow);
 
 
-/*
- * QCBOR_ENCODE_CONFIG_V1_COMPAT
- */
-static void
-QCBOREncode_Setv1Compatibility(QCBOREncodeContext *pCtx);
-
-
 /**
  * @brief  Add a signed 64-bit integer to the encoded output.
  *
@@ -3287,12 +3280,6 @@ QCBOREncode_Allow(QCBOREncodeContext *pMe, const uint8_t uAllow)
    (void)uAllow;
    (void)pMe;
 #endif /* ! QCBOR_DISABLE_ENCODE_USAGE_GUARDS */
-}
-
-static inline void
-QCBOREncode_Setv1Compatibility(QCBOREncodeContext *pMe)
-{
-   pMe->uConfig = QCBOR_ENCODE_CONFIG_V1_COMPAT;
 }
 
 

--- a/inc/qcbor/qcbor_private.h
+++ b/inc/qcbor/qcbor_private.h
@@ -231,20 +231,12 @@ typedef struct _QCBOREncodeContext QCBORPrivateEncodeContext;
 #define QCBOR_ENCODE_MODE_DCBOR     3
 
 
-// TODO: probably get rid of this
-/* Operate in compatibility with QCBOR 1.0
- * So far the differences are:
- *  - AddNegativeBigNum and AddBigFloat with a negative big num
- */
-#define QCBOR_ENCODE_CONFIG_V1_COMPAT 0x01
-
 struct _QCBOREncodeContext {
    /* PRIVATE DATA STRUCTURE */
    UsefulOutBuf      OutBuf;  /* Pointer to output buffer, its length and
                                * position in it. */
    uint8_t           uError;  /* Error state, always from QCBORError enum */
    uint8_t           uMode;   /* @ref QCBOR_ENCODE_MODE_PREFERRED or related */
-   uint8_t           uConfig; /* QCBOR_ENCODE_CONFIG_xxx */
    uint8_t           uAllow;  /* @ref QCBOR_ENCODE_ALLOW_NAN_PAYLOAD, ... */
    void            (*pfnCloseMap)(QCBORPrivateEncodeContext *); /* Use of function
                                * pointer explained in QCBOREncode_SerializationCDE() */

--- a/test/qcbor_encode_tests.c
+++ b/test/qcbor_encode_tests.c
@@ -3073,7 +3073,6 @@ struct EAMEncodeTest {
    UsefulBufC  BigNumMantissa;
    int64_t     nMantissa;
    bool        bSign;
-   bool        bv1Mode;
    enum {EAM_Any, EAM_Pref, EAM_CDE} eSerialization;
    // TODO: add tag requirement
 
@@ -3090,7 +3089,6 @@ struct EAMEncodeTest EET[] = {
       NULLUsefulBufC,
       3,
       false,
-      false,
       EAM_Pref,
 
       {"\xC5\x82\x20\x03", 4},
@@ -3103,7 +3101,6 @@ struct EAMEncodeTest EET[] = {
       -1,
       {"\x00\x03",2},
       0,
-      false,
       false,
       EAM_Pref,
 
@@ -3122,9 +3119,6 @@ static void
 EAMTestSetup(const struct EAMEncodeTest *pTest, QCBOREncodeContext *pEnc)
 {
    QCBOREncode_Init(pEnc, UsefulBuf_FROM_BYTE_ARRAY(spBigBuf));
-   if(pTest->bv1Mode) {
-      QCBOREncode_Setv1Compatibility(pEnc);
-   }
 
    switch(pTest->eSerialization) {
       case EAM_Pref:


### PR DESCRIPTION
The v1 compatibility mode is not needed for encode. There is no breaking change in v2 now.