### PR TITLE
Add API to encode bytestreams as references

### DIFF
--- a/inc/qcbor/qcbor_common.h
+++ b/inc/qcbor/qcbor_common.h
@@ -1,7 +1,7 @@
 /* ==========================================================================
  * Copyright (c) 2016-2018, The Linux Foundation.
  * Copyright (c) 2018-2024, Laurence Lundblade.
- * Copyright (c) 2021, Arm Limited.
+ * Copyright (c) 2021-2024, Arm Limited.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -299,6 +299,9 @@ typedef enum {
    /** Trying to cancel a byte string wrapping after items have been
     *  added to it. */
    QCBOR_ERR_CANNOT_CANCEL = 10,
+
+   /** This API cannot be used when external bytes are added to the encoding. */
+   QCBOR_ERR_CANNOT_BE_USED_WITH_EXTERNAL = 11,
 
 #define QCBOR_START_OF_NOT_WELL_FORMED_ERRORS 20
 

--- a/inc/qcbor/qcbor_common.h
+++ b/inc/qcbor/qcbor_common.h
@@ -303,6 +303,9 @@ typedef enum {
    /** This API cannot be used when external bytes are added to the encoding. */
    QCBOR_ERR_CANNOT_BE_USED_WITH_EXTERNAL = 11,
 
+   /** Too many externals were used before a nesting. */
+   QCBOR_ERR_TOO_MANY_EXTERNAL = 11,
+
 #define QCBOR_START_OF_NOT_WELL_FORMED_ERRORS 20
 
    /** During decoding, the CBOR is not well-formed because a simple

--- a/inc/qcbor/qcbor_private.h
+++ b/inc/qcbor/qcbor_private.h
@@ -168,6 +168,11 @@ extern "C" {
  */
 #define QCBOR_MAX_ARRAY_OFFSET  (UINT32_MAX - 100)
 
+/* The largest number of external references at the start of an array or map.
+ * The limit comes from uExternalStart in QCBORTrackNesting being uint8_t.
+ */
+#define QCBOR_MAX_EXTERNAL_POSITION  (UINT8_MAX)
+
 
 /* The number of tags that are 16-bit or larger that can be handled
  * in a decode.
@@ -191,9 +196,14 @@ extern "C" {
  * struct down so it can be on the stack without any concern.  It
  * would be about double if size_t was used instead.
  *
+ * uExternalStart stores the position of the first external reference in the
+ * encoding that is after the start of the array. If this was a pointer into the
+ * linked list, lookup would be faster, but the structure size would increase
+ * significantly.
+ *
  * Size approximation (varies with CPU/compiler):
- *    64-bit machine: (15 + 1) * (4 + 2 + 1 + 1 pad) + 8 = 136 bytes
- *   32-bit machine: (15 + 1) * (4 + 2 + 1 + 1 pad) + 4 = 132 bytes
+ *    64-bit machine: (15 + 1) * (4 + 2 + 1 + 1) + 8 = 136 bytes
+ *   32-bit machine: (15 + 1) * (4 + 2 + 1 + 1) + 4 = 132 bytes
  */
 typedef struct __QCBORTrackNesting {
   /* PRIVATE DATA STRUCTURE */
@@ -203,6 +213,7 @@ typedef struct __QCBORTrackNesting {
       uint16_t  uCount;   /* Number of items in the arrary or map; counts items
                            * in a map, not pairs of items */
       uint8_t   uMajorType; /* Indicates if item is a map or an array */
+      uint8_t   uExternalStart; /* Indicates the position of the first external after the array start */
    } pArrays[QCBOR_MAX_ARRAY_NESTING+1], /* stored state for nesting levels */
    *pCurrentNesting; /* the current nesting level */
 } QCBORTrackNesting;

--- a/test/qcbor_encode_tests.h
+++ b/test/qcbor_encode_tests.h
@@ -1,6 +1,7 @@
 /*==============================================================================
  Copyright (c) 2016-2018, The Linux Foundation.
  Copyright (c) 2018-2022, Laurence Lundblade.
+ Copyright (c) 2024, Arm Limited. All rights reserved.
  All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -193,5 +194,6 @@ int32_t OpenCloseBytesTest(void);
 
 int32_t SubStringTest(void);
 
+int32_t ExternalBufferTest(void);
 
 #endif /* defined(__QCBOR__qcbor_encode_tests__) */

--- a/test/run_tests.c
+++ b/test/run_tests.c
@@ -2,7 +2,7 @@
  run_tests.c -- test aggregator and results reporting
 
  Copyright (c) 2018-2024, Laurence Lundblade. All rights reserved.
- Copyright (c) 2021, Arm Limited. All rights reserved.
+ Copyright (c) 2021-2024, Arm Limited. All rights reserved.
 
  SPDX-License-Identifier: BSD-3-Clause
 
@@ -163,6 +163,7 @@ static test_entry s_tests[] = {
 #endif /* QCBOR_DISABLE_EXP_AND_MANTISSA */
     TEST_ENTRY(ParseEmptyMapInMapTest),
     TEST_ENTRY(SubStringTest),
+    TEST_ENTRY(ExternalBufferTest),
     TEST_ENTRY(BoolTest)
 };
 


### PR DESCRIPTION
This PR Introduces a new set of APIs for adding bytes to an encoded CBOR in a way that those bytes are not copied to the result buffer that is provided to the encoding context. Using any of the new APIs for adding data to a CBOR makes the QCBOREncode_Finish return an error, as the result buffer is not containing a valid CBOR in this case. Instead a new API is introduced to copy the encoded data in chunks to a user provided buffer.

The motivation for this PR is to be able to use QCBOR in constrained systems where there are large binary data blobs that need to be inserted in CBOR object. The data blobs are allocated outside, and for example mapped in the address space of the constrained system, but it doesn't have big enough memory of its own to hold the copy of the blobs.

This PR contains the new APIs, and some tests to validate the implementation. The change only affects the encoder implementation, it has no impact on the decoding side.

I added some documentation to the code to explain the usage of the new APIs, and explain how the references are stored and how the encoded CBOR is reconstructed using the references.

I'm not sure what would be the best terminology to be used for the new method of adding data to the CBOR. The APIs use the word 'external', like `QCBOREncode_Private_AddExternalBuffer`, but using the word `reference` may sound good as well, like `QCBOREncode_Private_AddBufferReference`.