### PR TITLE
Add API to encode bytestreams as references

### DIFF
--- a/inc/qcbor/qcbor_common.h
+++ b/inc/qcbor/qcbor_common.h
@@ -1,7 +1,7 @@
 /* ==========================================================================
  * Copyright (c) 2016-2018, The Linux Foundation.
  * Copyright (c) 2018-2024, Laurence Lundblade.
- * Copyright (c) 2021, Arm Limited.
+ * Copyright (c) 2021-2024, Arm Limited.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -305,6 +305,12 @@ typedef enum {
    /** Trying to cancel a byte string wrapping after items have been
     *  added to it. */
    QCBOR_ERR_CANNOT_CANCEL = 10,
+
+   /** This API cannot be used when external bytes are added to the encoding. */
+   QCBOR_ERR_CANNOT_BE_USED_WITH_EXTERNAL = 11,
+
+   /** Too many externals were used before a nesting. */
+   QCBOR_ERR_TOO_MANY_EXTERNAL = 11,
 
 #define QCBOR_START_OF_NOT_WELL_FORMED_ERRORS 20
 

--- a/inc/qcbor/qcbor_encode.h
+++ b/inc/qcbor/qcbor_encode.h
@@ -1,7 +1,7 @@
 /* ===========================================================================
  * Copyright (c) 2016-2018, The Linux Foundation.
  * Copyright (c) 2018-2024, Laurence Lundblade.
- * Copyright (c) 2021, Arm Limited.
+ * Copyright (c) 2021-2024, Arm Limited.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -72,8 +72,10 @@ extern "C" {
  * all CBOR can convert to JSON. See RFC 8949 for more info on how to
  * construct CBOR that is the most JSON friendly.
  *
- * The memory model for encoding and decoding is that encoded CBOR must
- * be in a contiguous buffer in memory.  During encoding the caller must
+ * The memory model for decoding is that encoded CBOR must be in a
+ * contiguous buffer in memory. In case of encoding it is possible that
+ * parts of the encoded CBOR are in multiple buffers scattered around in
+ * memory. For details see @ref Encoding. During encoding the caller must
  * supply an output buffer and if the encoding would go off the end of
  * the buffer an error is returned.  During decoding the caller supplies
  * the encoded CBOR in a contiguous buffer and the decoder returns
@@ -167,6 +169,25 @@ extern "C" {
  *
  * ## Encoding
  *
+ * QCBOR provides two modes for adding/storing data that is added to the
+ * encoded CBOR. Methods QCBOREncode_Add[DATA_TYPE](...) copy the data to
+ * the output buffer. QCBOREncode_AddExternal[DATA_TYPE](...) however
+ * doesn't write anything in the encoding buffer, but instead stores a
+ * reference to the data in the encoding context. These methods expect the
+ * data to be added wrapped in a @ref QCBORExternalBuffer structure. The
+ * address of this structure is saved in the Encoding context. Before
+ * calling the QCBOREncode_AddExternal[DATA_TYPE](...) method, the provided
+ * @ref QCBORExternalBuffer must be initialised with
+ * @ref QCBOREncode_InitExternalBuffer. If external data is added, then the
+ * encoding buffer doesn't contain a valid CBOR, so @ref QCBOREncode_Finish
+ * cannot be used to close the encoding, only @ref QCBOREncode_FinishGetSize.
+ * In this case the encoded CBOR can be obtained using the
+ * @ref QCBOREncode_CopyResult method.
+ *
+ * Note that the ...Add... and ...AddExternal... APIs for adding data to the
+ * CBOR can be used interleaved. This doesn't limit the scope of the CBOR
+ * structures that is possible to be encoded.
+ *
  * A common encoding usage mode is to invoke the encoding twice. First
  * with the output buffer as @ref SizeCalculateUsefulBuf to compute the
  * length of the needed output buffer. The correct sized output buffer
@@ -199,11 +220,11 @@ extern "C" {
  * valid during the @c QCBOREncode_AddXxx() calls as the data is copied
  * into the output buffer.
  *
- * There are three `Add` functions for each data type. The first / main
- * one for the type is for adding the data item to an array.  The second
- * one's name ends in `ToMap`, is used for adding data items to maps and
- * takes a string argument that is its label in the map. The third one
- * ends in `ToMapN`, is also used for adding data items to maps, and
+ * There are three `Add`/`AddExternal` functions for each data type. The
+ * first / main one for the type is for adding the data item to an array.
+ * The second one's name ends in `ToMap`, is used for adding data items to
+ * maps and takes a string argument that is its label in the map. The third
+ * one ends in `ToMapN`, is also used for adding data items to maps, and
  * takes an integer argument that is its label in the map.
  *
  * The simplest aggregate type is an array, which is a simple ordered
@@ -562,6 +583,25 @@ preferred serialization of type 0 and type 1 integers in QCBOR. */
  */
 typedef struct _QCBOREncodeContext QCBOREncodeContext;
 
+/**
+ * QCBOREncodeContext is the data type that holds reference to an external
+ * buffer. It is 16 bytes on 32 bit systems, 32 bytes on 64 bit systems, so it
+ * can go on the stack. The contents are opaque, and the caller should not
+ * access internal members. A pointer to this context is stored in the encoding
+ * context, so this structure can only be reused after the corresponding
+ * encoding context is not used anymore.
+ */
+typedef struct _QCBORExternalBuffer QCBORExternalBuffer;
+
+/**
+ * QCBOREncodeCopyContext is the data type that holds the context data for
+ * copying the encoded CBOR with external data. Multiple QCBOREncodeCopyContext
+ * might be used simultaneously for the same QCBOREncodeContext. A
+ * QCBOREncodeCopyContext contains a reference to the corresponding
+ * QCBOREncodeContext. the structure is 12 bytes on 32 bit systems, and 24 bytes
+ * on 64 bit systems.
+ */
+typedef struct _QCBOREncodeCopyContext QCBOREncodeCopyContext;
 
 /**
  * Initialize the encoder.
@@ -832,6 +872,17 @@ QCBOREncode_AddTextToMapSZ(QCBOREncodeContext *pCtx, const char *szLabel, Useful
 static void
 QCBOREncode_AddTextToMapN(QCBOREncodeContext *pCtx, int64_t nLabel, UsefulBufC Text);
 
+static void
+QCBOREncode_AddExternalText(QCBOREncodeContext *pCtx, QCBORExternalBuffer *pExternalBuffer);
+
+static void
+QCBOREncode_AddExternalTextToMapSZ(QCBOREncodeContext *pCtx, const char *szLabel,
+                                   QCBORExternalBuffer *pExternalBuffer);
+
+static void
+QCBOREncode_AddExternalTextToMapN(QCBOREncodeContext *pCtx, int64_t nLabel,
+                                  QCBORExternalBuffer *pExternalBuffer);
+
 
 /**
  * @brief  Add a UTF-8 text string to the encoded output.
@@ -849,6 +900,17 @@ QCBOREncode_AddSZStringToMapSZ(QCBOREncodeContext *pCtx, const char *szLabel, co
 
 static void
 QCBOREncode_AddSZStringToMapN(QCBOREncodeContext *pCtx, int64_t nLabel, const char *szString);
+
+static void
+QCBOREncode_AddExternalSZString(QCBOREncodeContext *pCtx, QCBORExternalBuffer *pExternalBuffer);
+
+static void
+QCBOREncode_AddExternalSZStringToMapSZ(QCBOREncodeContext *pCtx, const char *szLabel,
+                                       QCBORExternalBuffer *pExternalBuffer);
+
+static void
+QCBOREncode_AddExternalSZStringToMapN(QCBOREncodeContext *pCtx, int64_t nLabel,
+                                      QCBORExternalBuffer *pExternalBuffer);
 
 
 #ifndef USEFULBUF_DISABLE_ALL_FLOAT
@@ -1119,6 +1181,19 @@ QCBOREncode_AddBytesToMapSZ(QCBOREncodeContext *pCtx, const char *szLabel, Usefu
 
 static void
 QCBOREncode_AddBytesToMapN(QCBOREncodeContext *pCtx, int64_t nLabel, UsefulBufC Bytes);
+
+static void
+QCBOREncode_AddExternalBytes(QCBOREncodeContext *pCtx, QCBORExternalBuffer *pExternalBuffer);
+
+static void
+QCBOREncode_AddExternalBytesToMapSZ(QCBOREncodeContext *pCtx,
+                                    const char *szLabel,
+                                    QCBORExternalBuffer *pExternalBuffer);
+
+static void
+QCBOREncode_AddExternalBytesToMapN(QCBOREncodeContext *pCtx,
+                                   int64_t nLabel,
+                                   QCBORExternalBuffer *pExternalBuffer);
 
 
 /**
@@ -1724,6 +1799,23 @@ QCBOREncode_AddTB64TextToMapN(QCBOREncodeContext *pCtx,
                               uint8_t uTagRequirement,
                               UsefulBufC B64Text);
 
+static void
+QCBOREncode_AddExternalTB64Text(QCBOREncodeContext  *pCtx,
+                                uint8_t              uTagRequirement,
+                                QCBORExternalBuffer *pExternalBuffer);
+
+static void
+QCBOREncode_AddExternalTB64TextToMapSZ(QCBOREncodeContext  *pCtx,
+                                       const char          *szLabel,
+                                       uint8_t              uTagRequirement,
+                                       QCBORExternalBuffer *pExternalBuffer);
+
+static void
+QCBOREncode_AddExternalTB64TextToMapN(QCBOREncodeContext  *pCtx,
+                                      int64_t              nLabel,
+                                      uint8_t              uTagRequirement,
+                                      QCBORExternalBuffer *pExternalBuffer);
+
 
 /**
  * @brief Add base64url encoded data to encoded output.
@@ -1756,6 +1848,23 @@ QCBOREncode_AddTB64URLTextToMapN(QCBOREncodeContext *pCtx,
                                  int64_t             nLabel,
                                  uint8_t             uTagRequirement,
                                  UsefulBufC          B64Text);
+
+static void
+QCBOREncode_AddExternalTB64URLText(QCBOREncodeContext *pCtx,
+                           uint8_t              uTagRequirement,
+                           QCBORExternalBuffer *pExternalBuffer);
+
+static void
+QCBOREncode_AddExternalTB64URLTextToMapSZ(QCBOREncodeContext *pCtx,
+                                  const char          *szLabel,
+                                  uint8_t              uTagRequirement,
+                                  QCBORExternalBuffer *pExternalBuffer);
+
+static void
+QCBOREncode_AddExternalTB64URLTextToMapN(QCBOREncodeContext *pCtx,
+                                 int64_t              nLabel,
+                                 uint8_t              uTagRequirement,
+                                 QCBORExternalBuffer *pExternalBuffer);
 
 
 /**
@@ -2380,6 +2489,17 @@ QCBOREncode_AddEncodedToMapSZ(QCBOREncodeContext *pCtx, const char *szLabel, Use
 static void
 QCBOREncode_AddEncodedToMapN(QCBOREncodeContext *pCtx, int64_t nLabel, UsefulBufC Encoded);
 
+void
+QCBOREncode_AddExternalEncoded(QCBOREncodeContext *pCtx, QCBORExternalBuffer *pExternalBuffer);
+
+static void
+QCBOREncode_AddExternalEncodedToMapSZ(QCBOREncodeContext *pCtx, const char *szLabel,
+                                      QCBORExternalBuffer *pExternalBuffer);
+
+static void
+QCBOREncode_AddExternalEncodedToMapN(QCBOREncodeContext *pCtx, int64_t nLabel,
+                                     QCBORExternalBuffer *pExternalBuffer);
+
 
 /**
  * @brief Get the encoded result.
@@ -2388,21 +2508,23 @@ QCBOREncode_AddEncodedToMapN(QCBOREncodeContext *pCtx, int64_t nLabel, UsefulBuf
  * @param[out] pEncodedCBOR  Structure in which the pointer and length of
  *                           the encoded CBOR is returned.
  *
- * @retval QCBOR_SUCCESS                     Encoded CBOR is returned.
+ * @retval QCBOR_SUCCESS                          Encoded CBOR is returned.
  *
- * @retval QCBOR_ERR_TOO_MANY_CLOSES         Nesting error
+ * @retval QCBOR_ERR_TOO_MANY_CLOSES              Nesting error
  *
- * @retval QCBOR_ERR_CLOSE_MISMATCH          Nesting error
+ * @retval QCBOR_ERR_CLOSE_MISMATCH               Nesting error
  *
- * @retval QCBOR_ERR_ARRAY_OR_MAP_STILL_OPEN Nesting error
+ * @retval QCBOR_ERR_ARRAY_OR_MAP_STILL_OPEN      Nesting error
  *
- * @retval QCBOR_ERR_BUFFER_TOO_LARGE        Encoded output buffer size
+ * @retval QCBOR_ERR_BUFFER_TOO_LARGE             Encoded output buffer size
  *
- * @retval QCBOR_ERR_BUFFER_TOO_SMALL        Encoded output buffer size
+ * @retval QCBOR_ERR_BUFFER_TOO_SMALL             Encoded output buffer size
  *
- * @retval QCBOR_ERR_ARRAY_NESTING_TOO_DEEP  Implementation limit
+ * @retval QCBOR_ERR_ARRAY_NESTING_TOO_DEEP       Implementation limit
  *
- * @retval QCBOR_ERR_ARRAY_TOO_LONG          Implementation limit
+ * @retval QCBOR_ERR_ARRAY_TOO_LONG               Implementation limit
+ *
+ * @retval QCBOR_ERR_CANNOT_BE_USED_WITH_EXTERNAL External bytes were added to the CBOR
  *
  * On success, the pointer and length of the encoded CBOR are returned
  * in @c *pEncodedCBOR. The pointer is the same pointer that was passed
@@ -2450,26 +2572,85 @@ QCBOREncode_AddEncodedToMapN(QCBOREncodeContext *pCtx, int64_t nLabel, UsefulBuf
  * QCBOREncode_GetErrorState() can be called to get the current
  * error state in order to abort encoding early as an optimization, but
  * calling it is is never required.
+ *
+ * If external bytes were added to the CBOR during encoding, this function
+ * returns an error as the data in the buffer is not a well formed CBOR.
+ * QCBOREncode_FinishGetSize and QCBOREncode_CopyResult should be used instead.
  */
 QCBORError
 QCBOREncode_Finish(QCBOREncodeContext *pCtx, UsefulBufC *pEncodedCBOR);
 
 
 /**
- * @brief Get the encoded CBOR and error status.
+ * @brief Get the encoded CBOR length and error status.
  *
  * @param[in] pCtx          The context to finish encoding with.
  * @param[out] uEncodedLen  The length of the encoded or potentially
  *                          encoded CBOR in bytes.
  *
- * @return The same errors as QCBOREncode_Finish().
+ * @return The same errors as QCBOREncode_Finish() except
+ * @ref QCBOR_ERR_CANNOT_BE_USED_WITH_EXTERNAL is never returned.
  *
- * This functions the same as QCBOREncode_Finish(), but only returns the
- * size of the encoded output.
+ * This function is the same as QCBOREncode_Finish(), but only returns the size
+ * of the encoded CBOR including the sizes of the external buffers, if any.
  */
 QCBORError
 QCBOREncode_FinishGetSize(QCBOREncodeContext *pCtx, size_t *uEncodedLen);
 
+/**
+ * @brief Initialise an QCBORExternalBuffer structure
+ *
+ * @param[in] pExternalBuffer  the buffer structure to be initialised
+ * @param[in] Bytes            the buffer that is to be added to the encoded CBOR
+ *
+ * @retval QCBOR_SUCCESS
+ */
+QCBORError
+QCBOREncode_InitExternalBuffer(QCBORExternalBuffer *pExternalBuffer,
+                               const UsefulBufC Bytes);
+
+/**
+ * @brief Initialise an QCBOREncodeCopyContext structure
+ *
+ * @param[in]  pCopyContext   the context to be initialised
+ * @param[out] pEncodeContext the encoding context to associate pCopyContext with
+ *
+ * @retval QCBOR_SUCCESS
+ *
+ * The initialised QCBOREncodeCopyContext contains a reference to the
+ * QCBOREncodeContext, and becomes invalid once the content of
+ * QCBOREncodeContext is invalidated.
+ */
+QCBORError
+QCBOREncode_InitCopyResultContext(QCBOREncodeCopyContext *pCopyContext,
+                                  QCBOREncodeContext *pEncodeContext);
+
+
+/**
+ * @brief Copy the resulting cbor from the encoding context
+ *
+ * @param[in]  pMe              the encoding context that this buffer is used with
+ * @param[in]  pCopyContext     an initialised copy context
+ * @param[in]  TargetBuf        the target buffer to copy to
+ * @param[out] Result           the result of the copy
+ * @param[out] pBytesLeft       whether any bytes left to copy.
+ *
+ * @return The same errors as QCBOREncode_Finish() except
+ * @ref QCBOR_ERR_CANNOT_BE_USED_WITH_EXTERNAL is never returned.
+ *
+ * This function also copies the external bytes. The function always try to fill
+ * the target buffer. Subsequent calls to this function with the same copy
+ * context continue where the previous call finished.
+ *
+ * pBytesLeft can be used to decide whether a subsequent call is necessary to
+ * QCBOREncode_CopyResult or not.
+ */
+QCBORError
+QCBOREncode_CopyResult(QCBOREncodeContext *pMe,
+                       QCBOREncodeCopyContext *pCopyContext,
+                       UsefulBuf TargetBuf,
+                       UsefulBufC *Result,
+                       bool *pBytesLeft);
 
 /**
  * @brief Indicate whether the output storage buffer is NULL.
@@ -2571,7 +2752,7 @@ QCBOREncode_Tell(QCBOREncodeContext *pCtx);
  *
  * This will return @c NULLUsefulBufC if the encoder is in the error
  * state or if @c uStart is beyond the end of the thus-far encoded
- * data items.
+ * data items, or external bytes were added to the CBOR during encoding.
  *
  * If @c uStart is 0, all the thus-far-encoded CBOR will be returned.
  * Unlike QCBOREncode_Finish(), this will succeed even if some arrays
@@ -3164,6 +3345,11 @@ QCBOREncode_Private_AddBuffer(QCBOREncodeContext *pCtx,
                               uint8_t             uMajorType,
                               UsefulBufC          Bytes);
 
+/* Semi-private funcion used by public inline functions. See qcbor_encode.c */
+void
+QCBOREncode_Private_AddExternalBuffer(QCBOREncodeContext  *pMe,
+                                      const uint8_t        uMajorType,
+                                      QCBORExternalBuffer *pExternalBuffer);
 
 /* Semi-private function for adding a double with preferred encoding. See qcbor_encode.c */
 void
@@ -3401,6 +3587,30 @@ QCBOREncode_AddTextToMapN(QCBOREncodeContext *pMe,
    QCBOREncode_AddText(pMe, Text);
 }
 
+static inline void
+QCBOREncode_AddExternalText(QCBOREncodeContext *pMe, QCBORExternalBuffer *pExternalBuffer)
+{
+   QCBOREncode_Private_AddExternalBuffer(pMe, CBOR_MAJOR_TYPE_TEXT_STRING, pExternalBuffer);
+}
+
+static inline void
+QCBOREncode_AddExternalTextToMapSZ(QCBOREncodeContext *pMe,
+                                   const char         *szLabel,
+                                   QCBORExternalBuffer *pExternalBuffer)
+{
+   QCBOREncode_AddText(pMe, UsefulBuf_FromSZ(szLabel));
+   QCBOREncode_AddExternalText(pMe, pExternalBuffer);
+}
+
+static inline void
+QCBOREncode_AddExternalTextToMapN(QCBOREncodeContext *pMe,
+                                  const int64_t       nLabel,
+                                  QCBORExternalBuffer *pExternalBuffer)
+{
+   QCBOREncode_AddInt64(pMe, nLabel);
+   QCBOREncode_AddExternalText(pMe, pExternalBuffer);
+}
+
 
 inline static void
 QCBOREncode_AddSZString(QCBOREncodeContext *pMe, const char *szString)
@@ -3432,6 +3642,29 @@ QCBOREncode_AddSZStringToMapN(QCBOREncodeContext *pMe,
    QCBOREncode_AddSZString(pMe, szString);
 }
 
+inline static void
+QCBOREncode_AddExternalSZString(QCBOREncodeContext *pMe, QCBORExternalBuffer *pExternalBuffer)
+{
+   QCBOREncode_AddExternalText(pMe, pExternalBuffer);
+}
+
+static inline void
+QCBOREncode_AddExternalSZStringToMapSZ(QCBOREncodeContext *pMe,
+                               const char          *szLabel,
+                               QCBORExternalBuffer *pExternalBuffer)
+{
+   QCBOREncode_AddSZString(pMe, szLabel);
+   QCBOREncode_AddExternalSZString(pMe, pExternalBuffer);
+}
+
+static inline void
+QCBOREncode_AddExternalSZStringToMapN(QCBOREncodeContext *pMe,
+                              const int64_t        nLabel,
+                              QCBORExternalBuffer *pExternalBuffer)
+{
+   QCBOREncode_AddInt64(pMe, nLabel);
+   QCBOREncode_AddExternalSZString(pMe, pExternalBuffer);
+}
 
 static inline void
 QCBOREncode_AddTagNumber(QCBOREncodeContext *pMe, const uint64_t uTag)
@@ -3712,6 +3945,13 @@ QCBOREncode_AddBytes(QCBOREncodeContext *pMe,
 }
 
 static inline void
+QCBOREncode_AddExternalBytes(QCBOREncodeContext *pMe,
+                             QCBORExternalBuffer *pExternalBuffer)
+{
+   QCBOREncode_Private_AddExternalBuffer(pMe, CBOR_MAJOR_TYPE_BYTE_STRING, pExternalBuffer);
+}
+
+static inline void
 QCBOREncode_AddBytesToMapSZ(QCBOREncodeContext *pMe,
                             const char         *szLabel,
                             const UsefulBufC    Bytes)
@@ -3733,6 +3973,30 @@ QCBOREncode_AddBytesToMapN(QCBOREncodeContext *pMe,
 {
    QCBOREncode_AddInt64(pMe, nLabel);
    QCBOREncode_AddBytes(pMe, Bytes);
+}
+
+static inline void
+QCBOREncode_AddExternalBytesToMapSZ(QCBOREncodeContext *pMe,
+                            const char         *szLabel,
+                            QCBORExternalBuffer *pExternalBuffer)
+{
+   QCBOREncode_AddSZString(pMe, szLabel);
+   QCBOREncode_AddExternalBytes(pMe, pExternalBuffer);
+}
+
+static inline void
+QCBOREncode_AddExternalBytesToMap(QCBOREncodeContext *pMe, const char *szLabel, QCBORExternalBuffer *pExternalBuffer)
+{
+   QCBOREncode_AddExternalBytesToMapSZ(pMe, szLabel, pExternalBuffer);
+}
+
+static inline void
+QCBOREncode_AddExternalBytesToMapN(QCBOREncodeContext *pMe,
+                           const int64_t       nLabel,
+                           QCBORExternalBuffer *pExternalBuffer)
+{
+   QCBOREncode_AddInt64(pMe, nLabel);
+   QCBOREncode_AddExternalBytes(pMe, pExternalBuffer);
 }
 
 static inline void
@@ -4301,6 +4565,37 @@ QCBOREncode_AddTB64TextToMapN(QCBOREncodeContext *pMe,
 }
 
 static inline void
+QCBOREncode_AddExternalTB64Text(QCBOREncodeContext *pMe,
+                                const uint8_t       uTagRequirement,
+                                QCBORExternalBuffer *pExternalBuffer)
+{
+   if(uTagRequirement == QCBOR_ENCODE_AS_TAG) {
+      QCBOREncode_AddTag(pMe, CBOR_TAG_B64);
+   }
+   QCBOREncode_AddExternalText(pMe, pExternalBuffer);
+}
+
+static inline void
+QCBOREncode_AddExternalTB64TextToMapSZ(QCBOREncodeContext *pMe,
+                                       const char         *szLabel,
+                                       const uint8_t       uTagRequirement,
+                                       QCBORExternalBuffer *pExternalBuffer)
+{
+   QCBOREncode_AddSZString(pMe, szLabel);
+   QCBOREncode_AddExternalTB64Text(pMe, uTagRequirement, pExternalBuffer);
+}
+
+static inline void
+QCBOREncode_AddExternalTB64TextToMapN(QCBOREncodeContext *pMe,
+                                      const int64_t       nLabel,
+                                      const uint8_t       uTagRequirement,
+                                      QCBORExternalBuffer *pExternalBuffer)
+{
+   QCBOREncode_AddInt64(pMe, nLabel);
+   QCBOREncode_AddExternalTB64Text(pMe, uTagRequirement, pExternalBuffer);
+}
+
+static inline void
 QCBOREncode_AddB64Text(QCBOREncodeContext *pMe, const UsefulBufC B64Text)
 {
    QCBOREncode_AddTB64Text(pMe, QCBOR_ENCODE_AS_TAG, B64Text);
@@ -4353,6 +4648,37 @@ QCBOREncode_AddTB64URLTextToMapN(QCBOREncodeContext *pMe,
 {
    QCBOREncode_AddInt64(pMe, nLabel);
    QCBOREncode_AddTB64URLText(pMe, uTagRequirement, B64Text);
+}
+
+static inline void
+QCBOREncode_AddExternalTB64URLText(QCBOREncodeContext *pMe,
+                                   const uint8_t       uTagRequirement,
+                                   QCBORExternalBuffer *pExternalBuffer)
+{
+   if(uTagRequirement == QCBOR_ENCODE_AS_TAG) {
+      QCBOREncode_AddTag(pMe, CBOR_TAG_B64URL);
+   }
+   QCBOREncode_AddExternalText(pMe, pExternalBuffer);
+}
+
+static inline void
+QCBOREncode_AddExternalTB64URLTextToMapSZ(QCBOREncodeContext *pMe,
+                                          const char         *szLabel,
+                                          const uint8_t       uTagRequirement,
+                                          QCBORExternalBuffer *pExternalBuffer)
+{
+   QCBOREncode_AddSZString(pMe, szLabel);
+   QCBOREncode_AddExternalTB64URLText(pMe, uTagRequirement, pExternalBuffer);
+}
+
+static inline void
+QCBOREncode_AddExternalTB64URLTextToMapN(QCBOREncodeContext *pMe,
+                                         const int64_t       nLabel,
+                                         const uint8_t       uTagRequirement,
+                                         QCBORExternalBuffer *pExternalBuffer)
+{
+   QCBOREncode_AddInt64(pMe, nLabel);
+   QCBOREncode_AddExternalTB64URLText(pMe, uTagRequirement, pExternalBuffer);
 }
 
 static inline void
@@ -4904,6 +5230,24 @@ QCBOREncode_AddEncodedToMapN(QCBOREncodeContext *pMe,
 {
    QCBOREncode_AddInt64(pMe, nLabel);
    QCBOREncode_AddEncoded(pMe, Encoded);
+}
+
+static inline void
+QCBOREncode_AddExternalEncodedToMapSZ(QCBOREncodeContext *pMe,
+                            const char         *szLabel,
+                            QCBORExternalBuffer *pExternalBuffer)
+{
+   QCBOREncode_AddSZString(pMe, szLabel);
+   QCBOREncode_AddExternalEncoded(pMe, pExternalBuffer);
+}
+
+static inline void
+QCBOREncode_AddExternalEncodedToMapN(QCBOREncodeContext *pMe,
+                             const int64_t       nLabel,
+                             QCBORExternalBuffer *pExternalBuffer)
+{
+   QCBOREncode_AddInt64(pMe, nLabel);
+   QCBOREncode_AddExternalEncoded(pMe, pExternalBuffer);
 }
 
 

--- a/inc/qcbor/qcbor_private.h
+++ b/inc/qcbor/qcbor_private.h
@@ -1,7 +1,7 @@
 /* ==========================================================================
  * Copyright (c) 2016-2018, The Linux Foundation.
  * Copyright (c) 2018-2024, Laurence Lundblade.
- * Copyright (c) 2021, Arm Limited.
+ * Copyright (c) 2021-2024, Arm Limited.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -170,6 +170,11 @@ extern "C" {
  */
 #define QCBOR_MAX_ARRAY_OFFSET  (UINT32_MAX - 100)
 
+/* The largest number of external references at the start of an array or map.
+ * The limit comes from uExternalStart in QCBORTrackNesting being uint8_t.
+ */
+#define QCBOR_MAX_EXTERNAL_POSITION  (UINT8_MAX)
+
 
 /* The number of tags that are 16-bit or larger that can be handled
  * in a decode.
@@ -193,9 +198,14 @@ extern "C" {
  * struct down so it can be on the stack without any concern.  It
  * would be about double if size_t was used instead.
  *
+ * uExternalStart stores the position of the first external reference in the
+ * encoding that is after the start of the array. If this was a pointer into the
+ * linked list, lookup would be faster, but the structure size would increase
+ * significantly.
+ *
  * Size approximation (varies with CPU/compiler):
- *    64-bit machine: (15 + 1) * (4 + 2 + 1 + 1 pad) + 8 = 136 bytes
- *   32-bit machine: (15 + 1) * (4 + 2 + 1 + 1 pad) + 4 = 132 bytes
+ *    64-bit machine: (15 + 1) * (4 + 2 + 1 + 1) + 8 = 136 bytes
+ *   32-bit machine: (15 + 1) * (4 + 2 + 1 + 1) + 4 = 132 bytes
  */
 typedef struct __QCBORTrackNesting {
   /* PRIVATE DATA STRUCTURE */
@@ -205,20 +215,45 @@ typedef struct __QCBORTrackNesting {
       uint16_t  uCount;   /* Number of items in the arrary or map; counts items
                            * in a map, not pairs of items */
       uint8_t   uMajorType; /* Indicates if item is a map or an array */
+      uint8_t   uExternalStart; /* Indicates the position of the first external after the array start */
    } pArrays[QCBOR_MAX_ARRAY_NESTING+1], /* stored state for nesting levels */
    *pCurrentNesting; /* the current nesting level */
 } QCBORTrackNesting;
 
+/*
+ * PRIVATE DATA STRUCTURE
+ *
+ * Used to insert external buffer in an encoding
+ *
+ * When external buffers are added to a CBOR encoding, then a linked list of
+ * _QCBORExternalBuffer structures are built. The pNextExternalBuffer member
+ * in _QCBOREncodeContext points to the first element in the list, and the
+ * member of the same name in _QCBORExternalBuffer points to the next element in
+ * the list.
+ * The Bytes member contains the reference to the external buffer that is
+ * inserted in the encoded CBOR.
+ * uEncodedOffset contains the index in the encoding context's OutBuf where the
+ * content of Bytes will be inserted, once the CBOR object is copied by
+ * QCBOREncode_CopyResult
+ */
+struct _QCBORExternalBuffer{
+   /* PRIVATE DATA STRUCTURE */
+   struct _QCBORExternalBuffer *pNextExternalBuffer; /* The next such structure in the
+                                                      * linked list */
+   size_t uEncodedOffset; /* The offset in the encoding context's OutBuf where
+                           * this buffer must be inserted. */
+   UsefulBufC    Bytes;   /* The bytes to be inserted */
+};
 
 /*
  * PRIVATE DATA STRUCTURE
  *
  * Context / data object for encoding some CBOR. Used by all encode
- * functions to form a public "object" that does the job of encdoing.
+ * functions to form a public "object" that does the job of encoding.
  *
  * Size approximation (varies with CPU/compiler):
- *  64-bit machine: 27 + 1 (+ 4 padding) + 136 = 32 + 136 = 168 bytes
- *  32-bit machine: 15 + 1 + 132 = 148 bytes
+ *  64-bit machine: 8 + 27 + 1 (+ 4 padding) + 136 = 40 + 136 = 176 bytes
+ *  32-bit machine: 4 + 15 + 1 + 132 = 152 bytes
  */
 typedef struct _QCBOREncodeContext QCBORPrivateEncodeContext;
 
@@ -228,6 +263,8 @@ typedef struct _QCBOREncodeContext QCBORPrivateEncodeContext;
 
 struct _QCBOREncodeContext {
    /* PRIVATE DATA STRUCTURE */
+   struct _QCBORExternalBuffer *pNextExternalBuffer; /* The first such structure
+                                                      * in the linked list */
    UsefulOutBuf      OutBuf;  /* Pointer to output buffer, its length and
                                * position in it. */
    uint8_t           uError;  /* Error state, always from QCBORError enum */
@@ -237,6 +274,34 @@ struct _QCBOREncodeContext {
                                * pointer explained in TODO: */
    QCBORTrackNesting nesting; /* Keep track of array and map nesting */
 };
+
+
+/*
+ * PRIVATE DATA STRUCTURE
+ *
+ * Context / data object for copying output data including external buffers.
+ *
+ * uEncodeBuffOffset contains the offset of the next byte to be copied to the
+ * target buffer. Note, that if pNextExternalBuffer is not null, and the
+ * uEncodedOffset value is the same in the pointed _QCBORExternalBuffer
+ * structure, then the content of the external buffer will be next emitted by
+ * QCBOREncode_CopyResult. If all the bytes from the external buffer are
+ * emitted, then pNextExternalBuffer is updated to the next _QCBORExternalBuffer
+ * in the list. After this QCBOREncode_CopyResult will emit bytes form context's
+ * OutBuf, until uEncodeBuffOffset reaches pNextExternalBuffer's
+ * uEncodeBuffOffset (In theory this means that if uEncodeBuffOffset of the
+ * previous and the current _QCBORExternalBuffer structure is the same, then no
+ * bytes are emitted from the encoding context's OutBuf between the two).
+ * uExternalOffset contains the offset of the next byte to be emitted from the
+ * external buffer. When pNextExternalBuffer is updated, this field is set to 0.
+ */
+struct _QCBOREncodeCopyContext {
+   size_t            uEncodeBuffOffset; /* The offset in the encoded buffer during copy */
+   size_t            uExternalOffset; /* The offset in the current external buffer during copy */
+   struct _QCBORExternalBuffer *pNextExternalBuffer; /* The next such structure
+                                                      * in the linked list */
+};
+
 
 
 /*

--- a/src/qcbor_encode.c
+++ b/src/qcbor_encode.c
@@ -1,7 +1,7 @@
 /* ===========================================================================
  * Copyright (c) 2016-2018, The Linux Foundation.
  * Copyright (c) 2018-2024, Laurence Lundblade.
- * Copyright (c) 2021, Arm Limited.
+ * Copyright (c) 2021-2024, Arm Limited.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -90,7 +90,8 @@ Nesting_Init(QCBORTrackNesting *pNesting)
 static uint8_t
 Nesting_Increase(QCBORTrackNesting *pNesting,
                  const uint8_t      uMajorType,
-                 const uint32_t     uPos)
+                 const uint32_t     uPos,
+                 const uint8_t      uExternalPos)
 {
    if(pNesting->pCurrentNesting == &pNesting->pArrays[QCBOR_MAX_ARRAY_NESTING]) {
       return QCBOR_ERR_ARRAY_NESTING_TOO_DEEP;
@@ -99,6 +100,7 @@ Nesting_Increase(QCBORTrackNesting *pNesting,
       pNesting->pCurrentNesting->uCount     = 0;
       pNesting->pCurrentNesting->uStart     = uPos;
       pNesting->pCurrentNesting->uMajorType = uMajorType;
+      pNesting->pCurrentNesting->uExternalStart = uExternalPos;
       return QCBOR_SUCCESS;
    }
 }
@@ -156,6 +158,12 @@ static uint32_t
 Nesting_GetStartPos(QCBORTrackNesting *pNesting)
 {
    return pNesting->pCurrentNesting->uStart;
+}
+
+static uint8_t
+Nesting_GetExternalPos(QCBORTrackNesting *pNesting)
+{
+   return pNesting->pCurrentNesting->uExternalStart;
 }
 
 #ifndef QCBOR_DISABLE_ENCODE_USAGE_GUARDS
@@ -636,6 +644,73 @@ QCBOREncode_Private_AddBuffer(QCBOREncodeContext *pMe,
    UsefulOutBuf_AppendUsefulBuf(&(pMe->OutBuf), Bytes);
 }
 
+static QCBORError GetNextExternalPosition(QCBOREncodeContext *pMe, uint8_t* pPos) {
+   size_t uPos = 0;
+   QCBORExternalBuffer *pNextExternalBuffer = pMe->pNextExternalBuffer;
+
+   while(pNextExternalBuffer != NULL) {
+      ++uPos;
+      pNextExternalBuffer = pNextExternalBuffer->pNextExternalBuffer;
+   }
+
+   if (uPos > UINT8_MAX) {
+      return QCBOR_ERR_TOO_MANY_EXTERNAL;
+   }
+
+   *pPos = (uint8_t) uPos;
+
+   return QCBOR_SUCCESS;
+}
+
+static QCBORExternalBuffer *GetExternalAtPosition(QCBOREncodeContext *pMe, uint8_t pPos) {
+   QCBORExternalBuffer *pNextExternalBuffer = pMe->pNextExternalBuffer;
+
+   while(pPos > 0) {
+      if (pNextExternalBuffer == NULL) {
+         /* This is an internal error */
+         break;
+      }
+      --pPos;
+      pNextExternalBuffer = pNextExternalBuffer->pNextExternalBuffer;
+   }
+
+   return pNextExternalBuffer;
+}
+
+static void
+QCBOREncode_Private_InsertInExternalList(QCBOREncodeContext  *pMe,
+                                         QCBORExternalBuffer *pExternalBuffer)
+{
+   /* Insert the QCBORExternalBuffer in the linked list. */
+   /* First get to the tail of the external's list. */
+   QCBORExternalBuffer **ppTail = &(pMe->pNextExternalBuffer);
+   while (*ppTail != NULL) {
+      ppTail = &((*ppTail)->pNextExternalBuffer);
+   }
+   /* Then insert it after the last, and save the insertion point in it. */
+   *ppTail = pExternalBuffer;
+   pExternalBuffer->uEncodedOffset = pMe->OutBuf.data_len;
+}
+
+/**
+ * @brief Semi-private method to add an external buffer full of bytes to
+ * encoded output.
+ *
+ * @param[in] pMe             The encoding context to add the string to.
+ * @param[in] uMajorType      The CBOR major type of the bytes.
+ * @param[in] pExternalBuffer Reference to the bytes to be added.
+ *
+ * Called by inline functions to add text and byte strings.
+ */
+void
+QCBOREncode_Private_AddExternalBuffer(QCBOREncodeContext  *pMe,
+                                      const uint8_t        uMajorType,
+                                      QCBORExternalBuffer *pExternalBuffer)
+{
+   QCBOREncode_Private_AppendCBORHead(pMe, uMajorType, pExternalBuffer->Bytes.len, 0);
+   QCBOREncode_Private_InsertInExternalList(pMe, pExternalBuffer);
+}
+
 
 /*
  * Public function for adding raw encoded CBOR. See qcbor/qcbor_encode.h
@@ -644,6 +719,16 @@ void
 QCBOREncode_AddEncoded(QCBOREncodeContext *pMe, const UsefulBufC Encoded)
 {
    UsefulOutBuf_AppendUsefulBuf(&(pMe->OutBuf), Encoded);
+   QCBOREncode_Private_IncrementMapOrArrayCount(pMe);
+}
+
+/*
+ * Public function for adding raw encoded CBOR. See qcbor/qcbor_encode.h
+ */
+void
+QCBOREncode_AddExternalEncoded(QCBOREncodeContext *pMe, QCBORExternalBuffer *pExternalBuffer)
+{
+   QCBOREncode_Private_InsertInExternalList(pMe, pExternalBuffer);
    QCBOREncode_Private_IncrementMapOrArrayCount(pMe);
 }
 
@@ -1149,7 +1234,14 @@ QCBOREncode_Private_OpenMapOrArray(QCBOREncodeContext *pMe,
       /* Increase nesting level because this is a map or array.  Cast
        * from size_t to uin32_t is safe because of check above.
        */
-      pMe->uError = Nesting_Increase(&(pMe->nesting), uMajorType, (uint32_t)uEndPosition);
+      uint8_t uExternalPos;
+      QCBORError ret;
+      ret = GetNextExternalPosition(pMe, &uExternalPos);
+      if (ret != QCBOR_SUCCESS) {
+         pMe->uError = QCBOR_ERR_TOO_MANY_EXTERNAL;
+      } else{
+         pMe->uError = Nesting_Increase(&(pMe->nesting), uMajorType, (uint32_t)uEndPosition, uExternalPos);
+      }
    }
 }
 
@@ -1272,6 +1364,17 @@ QCBOREncode_Private_CloseAggregate(QCBOREncodeContext *pMe,
    UsefulOutBuf_InsertUsefulBuf(&(pMe->OutBuf),
                                 EncodedHead,
                                 Nesting_GetStartPos(&(pMe->nesting)));
+
+   /* If there are external buffers in the range that needs to be moved due to
+    * the insertion, move those as well.
+    */
+   QCBORExternalBuffer *pExternalBuffer =
+      GetExternalAtPosition(pMe, Nesting_GetExternalPos(&(pMe->nesting)));
+
+   while(pExternalBuffer != NULL) {
+      pExternalBuffer->uEncodedOffset += EncodedHead.len;
+      pExternalBuffer = pExternalBuffer->pNextExternalBuffer;
+   }
 
    Nesting_Decrease(&(pMe->nesting));
 }
@@ -1760,14 +1863,17 @@ QCBOREncode_Private_CloseMapOrArrayIndefiniteLength(QCBOREncodeContext *pMe,
 #endif /* ! QCBOR_DISABLE_INDEFINITE_LENGTH_ARRAYS */
 
 
-/*
- * Public function to finish and get the encoded result. See qcbor/qcbor_encode.h
- */
-QCBORError
-QCBOREncode_Finish(QCBOREncodeContext *pMe, UsefulBufC *pEncodedCBOR)
+static QCBORError
+QCBOREncode_Finish_Internal(QCBOREncodeContext *pMe,
+                            UsefulBufC *pEncodedCBOR,
+                            bool external_allowed)
 {
    if(QCBOREncode_GetErrorState(pMe) != QCBOR_SUCCESS) {
       goto Done;
+   }
+
+   if(!external_allowed && pMe->pNextExternalBuffer != NULL) {
+      return QCBOR_ERR_CANNOT_BE_USED_WITH_EXTERNAL;
    }
 
 #ifndef QCBOR_DISABLE_ENCODE_USAGE_GUARDS
@@ -1783,6 +1889,15 @@ Done:
    return pMe->uError;
 }
 
+/*
+ * Public function to finish and get the encoded result. See qcbor/qcbor_encode.h
+ */
+QCBORError
+QCBOREncode_Finish(QCBOREncodeContext *pMe, UsefulBufC *pEncodedCBOR)
+{
+   return QCBOREncode_Finish_Internal(pMe, pEncodedCBOR, false);
+}
+
 
 /*
  * Public function to get size of the encoded result. See qcbor/qcbor_encode.h
@@ -1791,14 +1906,159 @@ QCBORError
 QCBOREncode_FinishGetSize(QCBOREncodeContext *pMe, size_t *puEncodedLen)
 {
    UsefulBufC Enc;
+   size_t uLen = 0;
+   QCBORExternalBuffer *pNextExternalBuffer;
 
-   QCBORError nReturn = QCBOREncode_Finish(pMe, &Enc);
+   QCBORError nReturn = QCBOREncode_Finish_Internal(pMe, &Enc, true);
 
-   if(nReturn == QCBOR_SUCCESS) {
-      *puEncodedLen = Enc.len;
+   if(nReturn != QCBOR_SUCCESS) {
+      return nReturn;
    }
 
+   uLen += Enc.len;
+   pNextExternalBuffer = pMe->pNextExternalBuffer;
+   while (pNextExternalBuffer != NULL) {
+      uLen += pNextExternalBuffer->Bytes.len;
+      pNextExternalBuffer = pNextExternalBuffer->pNextExternalBuffer;
+   }
+
+   *puEncodedLen = uLen;
+
    return nReturn;
+}
+
+
+QCBORError
+QCBOREncode_InitExternalBuffer(QCBORExternalBuffer *pExternalBuffer,
+                               const UsefulBufC Bytes)
+{
+   memset(pExternalBuffer, 0, sizeof(*pExternalBuffer));
+   pExternalBuffer->Bytes = Bytes;
+   return QCBOR_SUCCESS;
+}
+
+QCBORError
+QCBOREncode_InitCopyResultContext(QCBOREncodeCopyContext *pCopyContext,
+                                  QCBOREncodeContext *pEncodeContext)
+{
+   memset(pCopyContext, 0, sizeof(*pCopyContext));
+   pCopyContext->pNextExternalBuffer = pEncodeContext->pNextExternalBuffer;
+   return QCBOR_SUCCESS;
+}
+
+/* Copies data to TargetBuf at target_offset from the buffer pointed by
+ * pCopyContext->pNextExternalBuffer.
+ *
+ * In case the buffer of pCopyContext->pNextExternalBuffer is exhausted then
+ * this function updates pCopyContext->pNextExternalBuffer to the next element
+ * in the linked list, and also resets pCopyContext->uExternalOffset to 0.
+ *
+ * Returns the number of bytes copied.
+ */
+static size_t CopyFromExternalBuffer(QCBOREncodeCopyContext *pCopyContext,
+                                     UsefulBuf TargetBuf,
+                                     size_t target_offset)
+{
+   size_t uBytesCopied = 0;
+   size_t uBytesleftInExternal = pCopyContext->pNextExternalBuffer->Bytes.len - pCopyContext->uExternalOffset;
+   size_t uBytesToCopy = TargetBuf.len - target_offset - uBytesCopied;
+   if (uBytesToCopy > uBytesleftInExternal) {
+      uBytesToCopy = uBytesleftInExternal;
+   }
+   memcpy((uint8_t *)TargetBuf.ptr + target_offset + uBytesCopied,
+            (const uint8_t *)(pCopyContext->pNextExternalBuffer->Bytes.ptr) + pCopyContext->uExternalOffset,
+            uBytesToCopy);
+   uBytesCopied += uBytesToCopy;
+   pCopyContext->uExternalOffset += uBytesToCopy;
+   if (uBytesleftInExternal == uBytesToCopy) {
+      pCopyContext->pNextExternalBuffer = pCopyContext->pNextExternalBuffer->pNextExternalBuffer;
+      pCopyContext->uExternalOffset = 0;
+   }
+   return uBytesCopied;
+}
+
+/*
+ * Copies data from pMe->OutBuf to TargetBuf at target_offset.
+ *
+ * It only copies bytes up until the uEncodeBuffOffset in
+ * pCopyContext->pNextExternalBuffer, if it is not null.
+ *
+ * Returns the number of bytes copied.
+ */
+static size_t CopyFromEncodeBuffer(QCBOREncodeContext *pMe,
+                                   QCBOREncodeCopyContext *pCopyContext,
+                                   UsefulBuf TargetBuf,
+                                   size_t target_offset)
+{
+   size_t uEncodeBufLen;
+   size_t uBytesCopied = 0;
+   if (pCopyContext->pNextExternalBuffer!= NULL) {
+      /* At this point pCopyContext->pNextExternalBuffer->uEncodedOffset >
+                        pCopyContext->uEncodeBuffOffset */
+      uEncodeBufLen = pCopyContext->pNextExternalBuffer->uEncodedOffset;
+   } else {
+      uEncodeBufLen = pMe->OutBuf.data_len;
+   }
+   size_t uBytesToCopy = TargetBuf.len - target_offset - uBytesCopied;
+   size_t uBytesLeftInBuffer = uEncodeBufLen - pCopyContext->uEncodeBuffOffset;
+   if (uBytesToCopy > uBytesLeftInBuffer)
+   {
+      uBytesToCopy = uBytesLeftInBuffer;
+   }
+   memcpy((uint8_t *)(TargetBuf.ptr) + target_offset + uBytesCopied,
+            (uint8_t *)(pMe->OutBuf.UB.ptr) + pCopyContext->uEncodeBuffOffset,
+            uBytesToCopy);
+   uBytesCopied += uBytesToCopy;
+   pCopyContext->uEncodeBuffOffset += uBytesCopied;
+   return uBytesCopied;
+}
+
+
+QCBORError
+QCBOREncode_CopyResult(QCBOREncodeContext *pMe,
+                       QCBOREncodeCopyContext *pCopyContext,
+                       UsefulBuf TargetBuf,
+                       UsefulBufC *Result,
+                       bool *pBytesLeft)
+{
+   size_t uBytesCopied = 0;
+   bool bytesLeft = true;
+
+   if(QCBOREncode_GetErrorState(pMe) != QCBOR_SUCCESS) {
+      goto Done;
+   }
+
+   while(uBytesCopied < TargetBuf.len) {
+      /* Check whether to copy from an external buffer */
+      if (pCopyContext->pNextExternalBuffer!= NULL &&
+          pCopyContext->pNextExternalBuffer->uEncodedOffset == pCopyContext->uEncodeBuffOffset) {
+         uBytesCopied += CopyFromExternalBuffer(pCopyContext, TargetBuf, uBytesCopied);
+         continue;
+      }
+
+      /* Copy from the encode context buffer */
+      if (pCopyContext->uEncodeBuffOffset < pMe->OutBuf.data_len) {
+         uBytesCopied += CopyFromEncodeBuffer(pMe, pCopyContext, TargetBuf, uBytesCopied);
+      }
+
+      if (pCopyContext->uEncodeBuffOffset == pMe->OutBuf.data_len &&
+          pCopyContext->pNextExternalBuffer == NULL) {
+         bytesLeft = false;
+         break;
+      }
+   }
+
+   if (pCopyContext->uEncodeBuffOffset == pMe->OutBuf.data_len &&
+         pCopyContext->pNextExternalBuffer == NULL) {
+      bytesLeft = false;
+   }
+
+   Result->ptr = TargetBuf.ptr;
+   Result->len = uBytesCopied;
+   *pBytesLeft = bytesLeft;
+
+Done:
+   return pMe->uError;
 }
 
 
@@ -1808,6 +2068,10 @@ QCBOREncode_FinishGetSize(QCBOREncodeContext *pMe, size_t *puEncodedLen)
 UsefulBufC
 QCBOREncode_SubString(QCBOREncodeContext *pMe, const size_t uStart)
 {
+   if(pMe->pNextExternalBuffer != NULL) {
+      return NULLUsefulBufC;
+   }
+
    if(pMe->uError) {
       return NULLUsefulBufC;
    }

--- a/test/qcbor_encode_tests.c
+++ b/test/qcbor_encode_tests.c
@@ -1,7 +1,7 @@
 /*==============================================================================
  Copyright (c) 2016-2018, The Linux Foundation.
  Copyright (c) 2018-2024, Laurence Lundblade.
- Copyright (c) 2022, Arm Limited. All rights reserved.
+ Copyright (c) 2022-2024, Arm Limited. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -4179,4 +4179,570 @@ int32_t SubStringTest(void)
    }
 
    return 0;
+}
+
+/* Compare the results of two encodings.
+ * EC is encoded without using external buffers, ECExt is encoded using external
+ * buffers.
+ *
+ * Returns 0 on success, non-zero otherwise
+ */
+static int32_t TestCopyResult(QCBOREncodeContext *EC, QCBOREncodeContext *ECExt)
+{
+   UsefulBufC Result;
+   uint8_t OutCopyBuffer[16];
+   UsefulBuf TargetBuf = {OutCopyBuffer, sizeof(OutCopyBuffer)};
+   UsefulBufC Encoded;
+   size_t EncodedLen;
+   size_t Gran;
+   QCBOREncodeCopyContext CopyContext;
+
+   if(QCBOREncode_Finish(EC, &Encoded)) {
+      return -1;
+   }
+   if(QCBOREncode_FinishGetSize(ECExt, &EncodedLen)) {
+      return -2;
+   }
+
+   if(Encoded.len != EncodedLen) {
+      return -3;
+   }
+
+   /* Call QCBOREncode_CopyResult with different granularities for greater coverage */
+   for(Gran = 1; Gran <= sizeof(OutCopyBuffer); ++Gran) {
+      if (QCBOREncode_InitCopyResultContext(&CopyContext, ECExt)) {
+         return -100 * (int)Gran - 1;
+      }
+
+      size_t offset = 0;
+      bool BytesLeft;
+      bool EndOfEncodedData;
+      TargetBuf.len = Gran;
+
+      /* call QCBOREncode_CopyResult while there is data left */
+      do {
+         if (QCBOREncode_CopyResult(ECExt, &CopyContext, TargetBuf, &Result, &BytesLeft)) {
+            return -100 * (int)Gran - 2;
+         }
+
+         if (Result.len > 0) {
+            if (memcmp(TargetBuf.ptr, (const uint8_t *)(Encoded.ptr) + offset, Result.len)) {
+               return -100 * (int)Gran - 3;
+            }
+         }
+
+         offset += Result.len;
+
+         EndOfEncodedData = (offset == EncodedLen);
+
+         if (BytesLeft == EndOfEncodedData) {
+            /* Some bytes left reported but end of data reached or
+             * no bytes left reported but not at the end of the data
+             */
+            return -100 * (int)Gran - 4;
+         }
+      } while (BytesLeft);
+
+      if (offset != EncodedLen) {
+         return -100 * (int)Gran - 5;
+      }
+
+      /* Call QCBOREncode_CopyResult again to verify it works with exhausted buffer */
+      if (QCBOREncode_CopyResult(ECExt, &CopyContext, TargetBuf, &Result, &BytesLeft)) {
+         return -100 * (int)Gran - 6;
+      }
+      if (BytesLeft) {
+         return -100 * (int)Gran - 7;
+      }
+      if (Result.len != 0) {
+         return -100 * (int)Gran - 8;
+      }
+
+   }
+   return 0;
+}
+/*
+ * spBigBuf is reused to testing encoding using external buffer like this:
+ *
+ * +---------+-----------------------+-----------------------+
+ * | ExtPool |      EncBufNoExt      |       EncBufExt       |
+ * +---------+-----------------------+-----------------------+
+ *
+ * Where
+ *  - ExtPool is a pool of QCBORExternalBuffer structures
+ *  - EncBufNoExt is a buffer that is used to initialise the encoding context
+ *    for the non-external API encoding
+ *  - EncBufExt is a buffer that is used to initialise the encoding context
+ *    for the external API encoding.
+ *
+ * For further details see the function ExternalBufferTest.
+ */
+
+#define EXT_BUF_COUNT 24
+#define EXT_BUF_POOL_SIZE (EXT_BUF_COUNT * sizeof(QCBORExternalBuffer))
+#define TEST_BUF_SIZE ((sizeof(spBigBuf) - EXT_BUF_POOL_SIZE) / 2)
+
+static char SZStringData[] = "test";
+static UsefulBufC SZStringDataUB = {SZStringData, sizeof(SZStringData) - 1};
+
+static UsefulBuf GetTestBuf(void) {
+   UsefulBuf buf = {&spBigBuf[EXT_BUF_POOL_SIZE], TEST_BUF_SIZE};
+   return buf;
+}
+
+static UsefulBuf GetTestBufExt(void) {
+   UsefulBuf buf = {&spBigBuf[EXT_BUF_POOL_SIZE + TEST_BUF_SIZE], TEST_BUF_SIZE};
+   return buf;
+}
+
+QCBORExternalBuffer *GetExtBufPool(void)
+{
+   return (QCBORExternalBuffer *)spBigBuf;
+}
+
+static void InitEncode(QCBOREncodeContext *EC, bool external)
+{
+   if (external) {
+      QCBOREncode_Init(EC, GetTestBufExt());
+   } else {
+      QCBOREncode_Init(EC, GetTestBuf());
+   }
+}
+
+/* Encode a CBOR without using external buffers */
+static void EncodeSimpleCbor(QCBOREncodeContext *EC)
+{
+   QCBOREncode_Init(EC, UsefulBuf_FROM_BYTE_ARRAY(spBigBuf));
+   QCBOREncode_AddInt64(EC, 1000);
+   QCBOREncode_AddInt64(EC, 500);
+}
+
+/* Encode a CBOR using a simple case of external (no array or map) */
+static void EncodeSimple1External(QCBOREncodeContext *EC, bool external)
+{
+   /* Reuse spCoseSign1Signature to save memory */
+   UsefulBufC Bytes = {spCoseSign1Signature, 8};
+   QCBORExternalBuffer *ExternalBuffers = GetExtBufPool();
+
+   InitEncode(EC, external);
+   QCBOREncode_AddInt64(EC, 1000);
+   if (external) {
+      QCBOREncode_InitExternalBuffer(&(ExternalBuffers[0]), Bytes);
+      QCBOREncode_AddExternalBytes(EC, &(ExternalBuffers[0]));
+   } else {
+      QCBOREncode_AddBytes(EC, Bytes);
+   }
+   QCBOREncode_AddInt64(EC, 500);
+}
+
+/* Encode a CBOR using externals: simple, array and map) */
+static int EncodeSimple3External(QCBOREncodeContext *EC, bool external)
+{
+   /* Reuse spCoseSign1Signature to save memory */
+   UsefulBufC Bytes0 = {spCoseSign1Signature, 8};
+   UsefulBufC Bytes1 = {spCoseSign1Signature + 8, 13};
+   UsefulBufC Bytes2 = {spCoseSign1Signature + 16, 5};
+   QCBORExternalBuffer *ExternalBuffers = GetExtBufPool();
+   size_t CurrentExtBufIndex = 0;
+
+   InitEncode(EC, external);
+   QCBOREncode_AddInt64(EC, 1000);
+   QCBOREncode_AddInt64(EC, 990);
+   if (external) {
+      QCBOREncode_InitExternalBuffer(&(ExternalBuffers[CurrentExtBufIndex]), Bytes0);
+      QCBOREncode_AddExternalBytes(EC, &(ExternalBuffers[CurrentExtBufIndex]));
+      ++CurrentExtBufIndex;
+      QCBOREncode_InitExternalBuffer(&(ExternalBuffers[CurrentExtBufIndex]), Bytes0);
+      QCBOREncode_AddExternalText(EC, &(ExternalBuffers[CurrentExtBufIndex]));
+      ++CurrentExtBufIndex;
+      QCBOREncode_InitExternalBuffer(&(ExternalBuffers[CurrentExtBufIndex]), SZStringDataUB);
+      QCBOREncode_AddExternalSZString(EC, &(ExternalBuffers[CurrentExtBufIndex]));
+      ++CurrentExtBufIndex;
+      QCBOREncode_InitExternalBuffer(&(ExternalBuffers[CurrentExtBufIndex]), Bytes0);
+      QCBOREncode_AddExternalTB64Text(EC, QCBOR_ENCODE_AS_TAG, &(ExternalBuffers[CurrentExtBufIndex]));
+      ++CurrentExtBufIndex;
+      QCBOREncode_InitExternalBuffer(&(ExternalBuffers[CurrentExtBufIndex]), Bytes0);
+      QCBOREncode_AddExternalTB64URLText(EC, QCBOR_ENCODE_AS_TAG, &(ExternalBuffers[CurrentExtBufIndex]));
+      ++CurrentExtBufIndex;
+      QCBOREncode_InitExternalBuffer(&(ExternalBuffers[CurrentExtBufIndex]), Bytes0);
+      QCBOREncode_AddExternalEncoded(EC, &(ExternalBuffers[CurrentExtBufIndex]));
+      ++CurrentExtBufIndex;
+   } else {
+      QCBOREncode_AddBytes(EC, Bytes0);
+      QCBOREncode_AddText(EC, Bytes0);
+      QCBOREncode_AddSZString(EC, SZStringData);
+      QCBOREncode_AddTB64Text(EC, QCBOR_ENCODE_AS_TAG, Bytes0);
+      QCBOREncode_AddTB64URLText(EC, QCBOR_ENCODE_AS_TAG, Bytes0);
+      QCBOREncode_AddEncoded(EC, Bytes0);
+   }
+
+   QCBOREncode_OpenMap(EC);
+   QCBOREncode_AddUInt64ToMapN(EC, 33, 5000);
+   if (external) {
+      QCBOREncode_InitExternalBuffer(&(ExternalBuffers[CurrentExtBufIndex]), Bytes1);
+      QCBOREncode_AddExternalBytesToMapN(EC, 55, &(ExternalBuffers[CurrentExtBufIndex]));
+      ++CurrentExtBufIndex;
+      QCBOREncode_InitExternalBuffer(&(ExternalBuffers[CurrentExtBufIndex]), Bytes1);
+      QCBOREncode_AddExternalBytesToMapSZ(EC, "str", &(ExternalBuffers[CurrentExtBufIndex]));
+      ++CurrentExtBufIndex;
+      QCBOREncode_InitExternalBuffer(&(ExternalBuffers[CurrentExtBufIndex]), Bytes1);
+      QCBOREncode_AddExternalTextToMapN(EC, 33, &(ExternalBuffers[CurrentExtBufIndex]));
+      ++CurrentExtBufIndex;
+      QCBOREncode_InitExternalBuffer(&(ExternalBuffers[CurrentExtBufIndex]), Bytes1);
+      QCBOREncode_AddExternalTextToMapSZ(EC, "str", &(ExternalBuffers[CurrentExtBufIndex]));
+      ++CurrentExtBufIndex;
+      QCBOREncode_InitExternalBuffer(&(ExternalBuffers[CurrentExtBufIndex]), SZStringDataUB);
+      QCBOREncode_AddExternalSZStringToMapN(EC, 42, &(ExternalBuffers[CurrentExtBufIndex]));
+      ++CurrentExtBufIndex;
+      QCBOREncode_InitExternalBuffer(&(ExternalBuffers[CurrentExtBufIndex]), SZStringDataUB);
+      QCBOREncode_AddExternalSZStringToMapSZ(EC, "str", &(ExternalBuffers[CurrentExtBufIndex]));
+      ++CurrentExtBufIndex;
+      QCBOREncode_InitExternalBuffer(&(ExternalBuffers[CurrentExtBufIndex]), Bytes1);
+      QCBOREncode_AddExternalTB64TextToMapN(EC, 57, QCBOR_ENCODE_AS_TAG, &(ExternalBuffers[CurrentExtBufIndex]));
+      ++CurrentExtBufIndex;
+      QCBOREncode_InitExternalBuffer(&(ExternalBuffers[CurrentExtBufIndex]), Bytes1);
+      QCBOREncode_AddExternalTB64TextToMapSZ(EC, "str", QCBOR_ENCODE_AS_TAG, &(ExternalBuffers[CurrentExtBufIndex]));
+      ++CurrentExtBufIndex;
+      QCBOREncode_InitExternalBuffer(&(ExternalBuffers[CurrentExtBufIndex]), Bytes1);
+      QCBOREncode_AddExternalTB64URLTextToMapN(EC, 96, QCBOR_ENCODE_AS_TAG, &(ExternalBuffers[CurrentExtBufIndex]));
+      ++CurrentExtBufIndex;
+      QCBOREncode_InitExternalBuffer(&(ExternalBuffers[CurrentExtBufIndex]), Bytes1);
+      QCBOREncode_AddExternalTB64URLTextToMapSZ(EC, "str", QCBOR_ENCODE_AS_TAG, &(ExternalBuffers[CurrentExtBufIndex]));
+      ++CurrentExtBufIndex;
+      QCBOREncode_InitExternalBuffer(&(ExternalBuffers[CurrentExtBufIndex]), Bytes1);
+      QCBOREncode_AddExternalEncodedToMapN(EC, 100, &(ExternalBuffers[CurrentExtBufIndex]));
+      ++CurrentExtBufIndex;
+      QCBOREncode_InitExternalBuffer(&(ExternalBuffers[CurrentExtBufIndex]), Bytes1);
+      QCBOREncode_AddExternalEncodedToMapSZ(EC, "str", &(ExternalBuffers[CurrentExtBufIndex]));
+      ++CurrentExtBufIndex;
+   } else {
+      QCBOREncode_AddBytesToMapN(EC, 55, Bytes1);
+      QCBOREncode_AddBytesToMapSZ(EC, "str", Bytes1);
+      QCBOREncode_AddTextToMapN(EC, 33, Bytes1);
+      QCBOREncode_AddTextToMapSZ(EC, "str", Bytes1);
+      QCBOREncode_AddSZStringToMapN(EC, 42, SZStringData);
+      QCBOREncode_AddSZStringToMapSZ(EC, "str", SZStringData);
+      QCBOREncode_AddTB64TextToMapN(EC, 57, QCBOR_ENCODE_AS_TAG, Bytes1);
+      QCBOREncode_AddTB64TextToMapSZ(EC, "str", QCBOR_ENCODE_AS_TAG, Bytes1);
+      QCBOREncode_AddTB64URLTextToMapN(EC, 96, QCBOR_ENCODE_AS_TAG, Bytes1);
+      QCBOREncode_AddTB64URLTextToMapSZ(EC, "str", QCBOR_ENCODE_AS_TAG, Bytes1);
+      QCBOREncode_AddEncodedToMapN(EC, 100, Bytes1);
+      QCBOREncode_AddEncodedToMapSZ(EC, "str", Bytes1);
+   }
+   QCBOREncode_CloseMap(EC);
+
+   QCBOREncode_OpenArray(EC);
+   if (external) {
+      QCBOREncode_InitExternalBuffer(&(ExternalBuffers[CurrentExtBufIndex]), Bytes2);
+      QCBOREncode_AddExternalBytes(EC, &(ExternalBuffers[CurrentExtBufIndex]));
+      ++CurrentExtBufIndex;
+      QCBOREncode_InitExternalBuffer(&(ExternalBuffers[CurrentExtBufIndex]), Bytes2);
+      QCBOREncode_AddExternalText(EC, &(ExternalBuffers[CurrentExtBufIndex]));
+      ++CurrentExtBufIndex;
+      QCBOREncode_InitExternalBuffer(&(ExternalBuffers[CurrentExtBufIndex]), SZStringDataUB);
+      QCBOREncode_AddExternalSZString(EC, &(ExternalBuffers[CurrentExtBufIndex]));
+      ++CurrentExtBufIndex;
+      QCBOREncode_InitExternalBuffer(&(ExternalBuffers[CurrentExtBufIndex]), Bytes2);
+      QCBOREncode_AddExternalTB64Text(EC, QCBOR_ENCODE_AS_TAG, &(ExternalBuffers[CurrentExtBufIndex]));
+      ++CurrentExtBufIndex;
+      QCBOREncode_InitExternalBuffer(&(ExternalBuffers[CurrentExtBufIndex]), Bytes2);
+      QCBOREncode_AddExternalTB64URLText(EC, QCBOR_ENCODE_AS_TAG, &(ExternalBuffers[CurrentExtBufIndex]));
+      ++CurrentExtBufIndex;
+      QCBOREncode_InitExternalBuffer(&(ExternalBuffers[CurrentExtBufIndex]), Bytes2);
+      QCBOREncode_AddExternalEncoded(EC, &(ExternalBuffers[CurrentExtBufIndex]));
+      ++CurrentExtBufIndex;
+   } else {
+      QCBOREncode_AddBytes(EC, Bytes2);
+      QCBOREncode_AddText(EC, Bytes2);
+      QCBOREncode_AddSZString(EC, SZStringData);
+      QCBOREncode_AddTB64Text(EC, QCBOR_ENCODE_AS_TAG, Bytes2);
+      QCBOREncode_AddTB64URLText(EC, QCBOR_ENCODE_AS_TAG, Bytes2);
+      QCBOREncode_AddEncoded(EC, Bytes2);
+   }
+   QCBOREncode_CloseArray(EC);
+
+   QCBOREncode_AddInt64(EC, 500);
+
+   if (CurrentExtBufIndex > EXT_BUF_COUNT) {
+      return -10000;
+   }
+   return 0;
+}
+
+/* Encode a CBOR using externals: with nesting) */
+static int EncodeNesting(QCBOREncodeContext *EC, bool external)
+{
+   /* Reuse spCoseSign1Signature to save memory */
+   UsefulBufC Bytes0 = {spCoseSign1Signature, 8};
+   UsefulBufC Bytes1 = {spCoseSign1Signature + 8, 13};
+   UsefulBufC Bytes2 = {spCoseSign1Signature + 16, 5};
+   QCBORExternalBuffer *ExternalBuffers = GetExtBufPool();
+   size_t CurrentExtBufIndex = 0;
+
+   InitEncode(EC, external);
+   QCBOREncode_AddInt64(EC, 1000);
+   QCBOREncode_AddInt64(EC, 990);
+   if (external) {
+      QCBOREncode_InitExternalBuffer(&(ExternalBuffers[CurrentExtBufIndex]), Bytes0);
+      QCBOREncode_AddExternalBytes(EC, &(ExternalBuffers[CurrentExtBufIndex]));
+      ++CurrentExtBufIndex;
+   } else {
+      QCBOREncode_AddBytes(EC, Bytes0);
+   }
+
+   QCBOREncode_OpenMap(EC);
+   QCBOREncode_AddUInt64ToMapN(EC, 33, 5000);
+   if (external) {
+      QCBOREncode_InitExternalBuffer(&(ExternalBuffers[CurrentExtBufIndex]), Bytes1);
+      QCBOREncode_AddExternalBytesToMapN(EC, 55, &(ExternalBuffers[CurrentExtBufIndex]));
+      ++CurrentExtBufIndex;
+   } else {
+      QCBOREncode_AddBytesToMapN(EC, 55, Bytes1);
+   }
+   QCBOREncode_OpenArrayInMapN(EC, 99);
+
+   if (external) {
+      QCBOREncode_InitExternalBuffer(&(ExternalBuffers[CurrentExtBufIndex]), SZStringDataUB);
+      QCBOREncode_AddExternalSZString(EC, &(ExternalBuffers[CurrentExtBufIndex]));
+      ++CurrentExtBufIndex;
+   } else {
+      QCBOREncode_AddSZString(EC, SZStringData);
+   }
+
+   QCBOREncode_OpenMap(EC);
+
+   if (external) {
+      QCBOREncode_InitExternalBuffer(&(ExternalBuffers[CurrentExtBufIndex]), Bytes1);
+      QCBOREncode_AddExternalBytesToMapN(EC, 13, &(ExternalBuffers[CurrentExtBufIndex]));
+      ++CurrentExtBufIndex;
+   } else {
+      QCBOREncode_AddBytesToMapN(EC, 13, Bytes1);
+   }
+
+   QCBOREncode_CloseMap(EC);
+
+   if (external) {
+      QCBOREncode_InitExternalBuffer(&(ExternalBuffers[CurrentExtBufIndex]), SZStringDataUB);
+      QCBOREncode_AddExternalSZString(EC, &(ExternalBuffers[CurrentExtBufIndex]));
+      ++CurrentExtBufIndex;
+   } else {
+      QCBOREncode_AddSZString(EC, SZStringData);
+   }
+   QCBOREncode_CloseArray(EC);
+   QCBOREncode_CloseMap(EC);
+
+   QCBOREncode_OpenArray(EC);
+   if (external) {
+      QCBOREncode_InitExternalBuffer(&(ExternalBuffers[CurrentExtBufIndex]), Bytes2);
+      QCBOREncode_AddExternalText(EC, &(ExternalBuffers[CurrentExtBufIndex]));
+      ++CurrentExtBufIndex;
+   } else {
+      QCBOREncode_AddText(EC, Bytes2);
+   }
+   QCBOREncode_CloseArray(EC);
+
+   QCBOREncode_AddInt64(EC, 500);
+
+   if (CurrentExtBufIndex > EXT_BUF_COUNT) {
+      return -10000;
+   }
+}
+
+/* Encode a CBOR external being the last element in the CBOR */
+static void EncodeExternalLast1(QCBOREncodeContext *EC, bool external)
+{
+   /* Reuse spCoseSign1Signature to save memory */
+   UsefulBufC Bytes0 = {spCoseSign1Signature, 8};
+   UsefulBufC Bytes1 = {spCoseSign1Signature + 8, 13};
+   QCBORExternalBuffer *ExternalBuffers = GetExtBufPool();
+
+   InitEncode(EC, external);
+   QCBOREncode_AddInt64(EC, 1000);
+   QCBOREncode_AddInt64(EC, 990);
+   if (external) {
+      QCBOREncode_InitExternalBuffer(&(ExternalBuffers[0]), Bytes0);
+      QCBOREncode_AddExternalBytes(EC, &(ExternalBuffers[0]));
+   } else {
+      QCBOREncode_AddBytes(EC, Bytes0);
+   }
+
+   QCBOREncode_OpenMap(EC);
+   QCBOREncode_AddUInt64ToMapN(EC, 33, 5000);
+   if (external) {
+      QCBOREncode_InitExternalBuffer(&(ExternalBuffers[1]), Bytes1);
+      QCBOREncode_AddExternalBytesToMapN(EC, 55, &(ExternalBuffers[1]));
+   } else {
+      QCBOREncode_AddBytesToMapN(EC, 55, Bytes1);
+   }
+   QCBOREncode_CloseMap(EC);
+}
+
+/* Encode a CBOR external being the last element in the CBOR in an array */
+static void EncodeExternalLast2(QCBOREncodeContext *EC, bool external)
+{
+   /* Reuse spCoseSign1Signature to save memory */
+   UsefulBufC Bytes0 = {spCoseSign1Signature, 8};
+   UsefulBufC Bytes1 = {spCoseSign1Signature + 8, 13};
+   QCBORExternalBuffer *ExternalBuffers = GetExtBufPool();
+
+   InitEncode(EC, external);
+   QCBOREncode_AddInt64(EC, 1000);
+   QCBOREncode_AddInt64(EC, 990);
+   if (external) {
+      QCBOREncode_InitExternalBuffer(&(ExternalBuffers[0]), Bytes0);
+      QCBOREncode_AddExternalBytes(EC, &(ExternalBuffers[0]));
+   } else {
+      QCBOREncode_AddBytes(EC, Bytes0);
+   }
+
+   QCBOREncode_OpenArray(EC);
+   if (external) {
+      QCBOREncode_InitExternalBuffer(&(ExternalBuffers[1]), Bytes1);
+      QCBOREncode_AddExternalBytes(EC, &(ExternalBuffers[1]));
+   } else {
+      QCBOREncode_AddBytes(EC, Bytes1);
+   }
+   QCBOREncode_CloseArray(EC);
+}
+
+/* Encode a CBOR external being the last element in the CBOR in a map */
+static void EncodeExternalLast3(QCBOREncodeContext *EC, bool external)
+{
+   /* Reuse spCoseSign1Signature to save memory */
+   UsefulBufC Bytes0 = {spCoseSign1Signature, 8};
+   QCBORExternalBuffer *ExternalBuffers = GetExtBufPool();
+
+   InitEncode(EC, external);
+   QCBOREncode_AddInt64(EC, 1000);
+   QCBOREncode_AddInt64(EC, 990);
+   if (external) {
+      QCBOREncode_InitExternalBuffer(&(ExternalBuffers[0]), Bytes0);
+      QCBOREncode_AddExternalBytes(EC, &(ExternalBuffers[0]));
+   } else {
+      QCBOREncode_AddBytes(EC, Bytes0);
+   }
+}
+
+/* Encode a cbor using 0 long byte buffers */
+static void EncodeSimple3ZeroExternal(QCBOREncodeContext *EC, bool external)
+{
+   UsefulBufC Bytes0 = {NULL, 0};
+   QCBORExternalBuffer *ExternalBuffers = GetExtBufPool();
+
+   InitEncode(EC, external);
+   QCBOREncode_AddInt64(EC, 1000);
+   QCBOREncode_AddInt64(EC, 990);
+   if (external) {
+      QCBOREncode_InitExternalBuffer(&(ExternalBuffers[0]), Bytes0);
+      QCBOREncode_AddExternalBytes(EC, &(ExternalBuffers[0]));
+   } else {
+      QCBOREncode_AddBytes(EC, Bytes0);
+   }
+
+   QCBOREncode_OpenMap(EC);
+   QCBOREncode_AddUInt64ToMapN(EC, 33, 5000);
+   if (external) {
+      QCBOREncode_InitExternalBuffer(&(ExternalBuffers[1]), Bytes0);
+      QCBOREncode_AddExternalBytesToMapN(EC, 55, &(ExternalBuffers[1]));
+   } else {
+      QCBOREncode_AddBytesToMapN(EC, 55, Bytes0);
+   }
+   QCBOREncode_CloseMap(EC);
+
+   QCBOREncode_OpenArray(EC);
+   if (external) {
+      QCBOREncode_InitExternalBuffer(&(ExternalBuffers[2]), Bytes0);
+      QCBOREncode_AddExternalBytes(EC, &(ExternalBuffers[2]));
+   } else {
+      QCBOREncode_AddBytes(EC, Bytes0);
+   }
+   QCBOREncode_CloseArray(EC);
+
+   QCBOREncode_AddInt64(EC, 500);
+}
+
+/*
+ * The idea of the testing is to encode the same data in two separate contexts.
+ * In the first case without using external buffers, in the second case use
+ * external buffers (according to the test scenario). Then call TestCopyResult
+ * which compares the output of QCBOREncode_CopyResult with the encoding buffer
+ * of the first case.
+ */
+int32_t ExternalBufferTest(void)
+{
+   QCBOREncodeContext EC;
+   QCBOREncodeContext ECExt;
+   UsefulBufC Encoded;
+   int32_t ret;
+
+   /* Do test without using externals */
+   EncodeSimpleCbor(&EC);
+   ret = TestCopyResult(&EC, &EC);
+   if (ret) {
+      return ret;
+   }
+
+   /* Do test with single external */
+   EncodeSimple1External(&EC, false);
+   EncodeSimple1External(&ECExt, true);
+   /* Make sure that QCBOREncode_Finish throws error when externals are used */
+   if(QCBOREncode_Finish(&ECExt, &Encoded) !=
+      QCBOR_ERR_CANNOT_BE_USED_WITH_EXTERNAL) {
+      return -50;
+   }
+   ret = TestCopyResult(&EC, &ECExt);
+   if (ret) {
+      return ret;
+   }
+
+   ret = EncodeSimple3External(&EC, false);
+   if (ret) {
+      return ret;
+   }
+   ret = EncodeSimple3External(&ECExt, true);
+   if (ret) {
+      return ret;
+   }
+   ret = TestCopyResult(&EC, &ECExt);
+   if (ret) {
+      return ret;
+   }
+
+   EncodeExternalLast1(&EC, false);
+   EncodeExternalLast1(&ECExt, true);
+   ret = TestCopyResult(&EC, &ECExt);
+   if (ret) {
+      return ret;
+   }
+
+   EncodeExternalLast2(&EC, false);
+   EncodeExternalLast2(&ECExt, true);
+   ret = TestCopyResult(&EC, &ECExt);
+   if (ret) {
+      return ret;
+   }
+
+   EncodeExternalLast3(&EC, false);
+   EncodeExternalLast3(&ECExt, true);
+   ret = TestCopyResult(&EC, &ECExt);
+   if (ret) {
+      return ret;
+   }
+
+   EncodeSimple3ZeroExternal(&EC, false);
+   EncodeSimple3ZeroExternal(&ECExt, true);
+   ret = TestCopyResult(&EC, &ECExt);
+   if (ret) {
+      return ret;
+   }
+
+   EncodeNesting(&EC, false);
+   EncodeNesting(&ECExt, true);
+   ret = TestCopyResult(&EC, &ECExt);
+   if (ret) {
+      return ret;
+   }
+
+   return 0;
+
 }

--- a/test/qcbor_encode_tests.h
+++ b/test/qcbor_encode_tests.h
@@ -1,6 +1,7 @@
 /*==============================================================================
  Copyright (c) 2016-2018, The Linux Foundation.
  Copyright (c) 2018-2024, Laurence Lundblade.
+ Copyright (c) 2024, Arm Limited. All rights reserved.
  All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -206,5 +207,6 @@ int32_t DCBORTest(void);
 
 int32_t SubStringTest(void);
 
+int32_t ExternalBufferTest(void);
 
 #endif /* defined(__QCBOR__qcbor_encode_tests__) */

--- a/test/run_tests.c
+++ b/test/run_tests.c
@@ -2,7 +2,7 @@
  run_tests.c -- test aggregator and results reporting
 
  Copyright (c) 2018-2024, Laurence Lundblade. All rights reserved.
- Copyright (c) 2021, Arm Limited. All rights reserved.
+ Copyright (c) 2021-2024, Arm Limited. All rights reserved.
 
  SPDX-License-Identifier: BSD-3-Clause
 
@@ -181,6 +181,7 @@ static test_entry s_tests[] = {
 #endif /* ! USEFULBUF_DISABLE_ALL_FLOAT && ! QCBOR_DISABLE_PREFERRED_FLOAT */
     TEST_ENTRY(ParseEmptyMapInMapTest),
     TEST_ENTRY(SubStringTest),
+    TEST_ENTRY(ExternalBufferTest),
     TEST_ENTRY(BoolTest)
 };
 


### PR DESCRIPTION
This PR Introduces a new set of APIs for adding bytes to an encoded CBOR in a way that those bytes are not copied to the result buffer that is provided to the encoding context. Using any of the new APIs for adding data to a CBOR makes the QCBOREncode_Finish return an error, as the result buffer is not containing a valid CBOR in this case. Instead a new API is introduced to copy the encoded data in chunks to a user provided buffer.

The motivation for this PR is to be able to use QCBOR in constrained systems where there are large binary data blobs that need to be inserted in CBOR object. The data blobs are allocated outside, and for example mapped in the address space of the constrained system, but it doesn't have big enough memory of its own to hold the copy of the blobs.

This PR contains the new APIs, and some tests to validate the implementation. The change only affects the encoder implementation, it has no impact on the decoding side.

I added some documentation to the code to explain the usage of the new APIs, and explain how the references are stored and how the encoded CBOR is reconstructed using the references.

I'm not sure what would be the best terminology to be used for the new method of adding data to the CBOR. The APIs use the word 'external', like QCBOREncode_Private_AddExternalBuffer, but using the word reference may sound good as well, like QCBOREncode_Private_AddBufferReference.