### PR TITLE
EnterBstr error handling bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ QCBOR.
 
 This is the 2.0 alpha release. It has large changes and feature
 additions. It's not ready for commericial use yet. The main short
-coming the need for more testing of the newer features. It will
+coming is the need for more testing of the newer features. It will
 go through alpha, then to beta and then to an official 2.0
 commerical release sometimes in 2025.
 
@@ -232,5 +232,5 @@ EAT and CWT.
 
 ### Copyright for this README
 
-Copyright (c) 2018-2024, Laurence Lundblade. All rights reserved.
+Copyright (c) 2018-2025, Laurence Lundblade. All rights reserved.
 Copyright (c) 2021-2023, Arm Limited. All rights reserved.

--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ Replaced by RFC 8949.
   with the test suite. The test suite dependencies are minimal and the
   same as the library's.
 
+## Documentation
+
+Full API documentation is at https://www.securitytheory.com/qcbor-docs/
 
 ## Comparison to TinyCBOR
 

--- a/doc/mainpage.dox
+++ b/doc/mainpage.dox
@@ -1,6 +1,10 @@
 /*! @mainpage QCBOR Documentation
 
-QCBOR is available for download @ref https://github.com/laurencelundblade/QCBOR "here on GitHub"
+QCBOR can be downloaded from its [GitHub repository](https://github.com/laurencelundblade/QCBOR).
+This documentation corresponds to QCBOR v2, currently in its alpha release
+phase. While much of the content also applies to v1 -- which is stable,
+commercially suitable, and compatible with v2 -- it's important to note that
+v2 introduces new features and APIs not available in v1.
 
 @par Table of Contents
 
@@ -17,10 +21,6 @@ API Reference:
    - Spiffy decode functions: @ref inc/qcbor/qcbor_spiffy_decode.h "qcbor_spiffy_decode.h"
    - Tag decode functions: @ref inc/qcbor/qcbor_tag_decode.h "qcbor_tag_decode.h"
    - Number decode functions: @ref inc/qcbor/qcbor_number_decode.h "qcbor_number_decode.h"
-
-Note:
-- This is for QCBOR v2, but v1 is largely compatible
-- the API Reference is largely complete, the subject matter below is partial
 
 Subject Matter:
 - @ref Overview "QCBOR overview and implementation limits"

--- a/pkg/qcbor.spec
+++ b/pkg/qcbor.spec
@@ -1,12 +1,12 @@
 # Guidelines from https://docs.fedoraproject.org/en-US/packaging-guidelines/CMake/
 
 Name: qcbor
-Version: 1.5.0
+Version: 2.0.0.a1
 Release: 0%{?dist}
 Summary: A CBOR encoder/decoder library
 URL: https://github.com/laurencelundblade/QCBOR
 License: BSD-3-Clause
-Source0: %{URL}/archive/refs/tags/v1.5.tar.gz
+Source0: %{URL}/archive/refs/tags/v2.0.tar.gz
 
 BuildRequires: cmake
 BuildRequires: gcc
@@ -24,7 +24,7 @@ Development files needed to build and link to the QCBOR library.
 
 
 %prep
-%setup -q -n QCBOR-1.5
+%setup -q -n QCBOR-2.0
 %cmake -DBUILD_QCBOR_TEST=APP
 
 
@@ -53,5 +53,5 @@ Development files needed to build and link to the QCBOR library.
 
 
 %changelog
-* Fri Dec 20 2024 Laurence Lundblade <lgl@island-resort.com> - 1.5.0-0
-- Initial library RPM packaging.
+* Fri Dec 20 2024 Laurence Lundblade <lgl@island-resort.com> - 2.0.0.a1
+- QCBOR 2.0 alpha release 1. Not ready for commercial use.

--- a/src/qcbor_tag_decode.c
+++ b/src/qcbor_tag_decode.c
@@ -632,7 +632,7 @@ QCBORDecode_Private_EnterBstrWrapped(QCBORDecodeContext          *pMe,
                                              &bTypeMatched);
 
    if(pItem->uDataType != QCBOR_TYPE_BYTE_STRING) {
-      uError = QCBOR_ERR_BAD_TAG_CONTENT; // TODO: error
+      return QCBOR_ERR_UNEXPECTED_TYPE;
    }
 
 

--- a/test/qcbor_decode_tests.c
+++ b/test/qcbor_decode_tests.c
@@ -8858,6 +8858,26 @@ int32_t EnterBstrTest(void)
       return 300 + (int32_t)uErr;
    }
 
+   /* Try to enter some thing that is not a bstr */
+   QCBORDecode_Init(&DC,
+                    UsefulBuf_FROM_BYTE_ARRAY_LITERAL(spArrayOfEmpty),
+                    0);
+   QCBORDecode_EnterBstrWrapped(&DC, QCBOR_TAG_REQUIREMENT_NOT_A_TAG, NULL);
+   uErr = QCBORDecode_GetError(&DC);
+   if(uErr != QCBOR_ERR_UNEXPECTED_TYPE) {
+      return 400 + (int32_t)uErr;
+   }
+
+   /* Try to enter some thing else that is not a bstr */
+   QCBORDecode_Init(&DC,
+                    UsefulBuf_FROM_BYTE_ARRAY_LITERAL(spEmptyMap),
+                    0);
+   QCBORDecode_EnterBstrWrapped(&DC, QCBOR_TAG_REQUIREMENT_NOT_A_TAG, NULL);
+   uErr = QCBORDecode_GetError(&DC);
+   if(uErr != QCBOR_ERR_UNEXPECTED_TYPE) {
+      return 500 + (int32_t)uErr;
+   }
+
    return 0;
 }
 


### PR DESCRIPTION
The wrong error code was returned when using EnterBstr on something that is not a bstr. The bug is only in QCBOR v2.