### PR TITLE
EnterBstr() error handling bug

### DIFF
--- a/src/qcbor_tag_decode.c
+++ b/src/qcbor_tag_decode.c
@@ -632,7 +632,7 @@ QCBORDecode_Private_EnterBstrWrapped(QCBORDecodeContext          *pMe,
                                              &bTypeMatched);
 
    if(pItem->uDataType != QCBOR_TYPE_BYTE_STRING) {
-      uError = QCBOR_ERR_BAD_TAG_CONTENT; // TODO: error
+      return QCBOR_ERR_UNEXPECTED_TYPE;
    }
 
 

--- a/test/qcbor_decode_tests.c
+++ b/test/qcbor_decode_tests.c
@@ -8858,6 +8858,26 @@ int32_t EnterBstrTest(void)
       return 300 + (int32_t)uErr;
    }
 
+   /* Try to enter some thing that is not a bstr */
+   QCBORDecode_Init(&DC,
+                    UsefulBuf_FROM_BYTE_ARRAY_LITERAL(spArrayOfEmpty),
+                    0);
+   QCBORDecode_EnterBstrWrapped(&DC, QCBOR_TAG_REQUIREMENT_NOT_A_TAG, NULL);
+   uErr = QCBORDecode_GetError(&DC);
+   if(uErr != QCBOR_ERR_UNEXPECTED_TYPE) {
+      return 400 + (int32_t)uErr;
+   }
+
+   /* Try to enter some thing else that is not a bstr */
+   QCBORDecode_Init(&DC,
+                    UsefulBuf_FROM_BYTE_ARRAY_LITERAL(spEmptyMap),
+                    0);
+   QCBORDecode_EnterBstrWrapped(&DC, QCBOR_TAG_REQUIREMENT_NOT_A_TAG, NULL);
+   uErr = QCBORDecode_GetError(&DC);
+   if(uErr != QCBOR_ERR_UNEXPECTED_TYPE) {
+      return 500 + (int32_t)uErr;
+   }
+
    return 0;
 }
 


### PR DESCRIPTION
EnterBstr() gave the wrong error code when trying to use it on something that is not a bstr. Bug was in QCBOR v2, not v1.