### PR TITLE
Improve encde and UsefulBuf test coverage; UsefulOutBuf_Compare() fixes

### DIFF
--- a/inc/qcbor/UsefulBuf.h
+++ b/inc/qcbor/UsefulBuf.h
@@ -1,6 +1,6 @@
 /* =========================================================================
  * Copyright (c) 2016-2018, The Linux Foundation.
- * Copyright (c) 2018-2024, Laurence Lundblade.
+ * Copyright (c) 2018-2025, Laurence Lundblade.
  * Copyright (c) 2021, Arm Limited. All rights reserved.
  * All rights reserved.
  *
@@ -43,6 +43,8 @@
 
  when         who             what, where, why
  --------     ----            --------------------------------------------------
+ 02/21/2025   llundblade      Correct documentaion for UsefulOutBuf_Compare()
+ 02/21/2025   llundblade      Rename to UsefulOutBuf_OutSubString().
  12/31/2024   llundblade      Minor documentation tweaks for Doxygen.
  08/31/2024   llundblade      Add UsefulBufC_NTH_BYTE().
  08/14/2024   llundblade      Add UsefulOutBuf_RetrieveOutputStorage().

--- a/inc/qcbor/UsefulBuf.h
+++ b/inc/qcbor/UsefulBuf.h
@@ -1452,9 +1452,9 @@ UsefulOutBuf_OutUBufOffset(UsefulOutBuf *pUOutBuf, size_t uOffset);
  * substring. @c NULLUsefulBufC is returned if the requested substring
  * is off the end of the output bytes or if in error state.
  */
-UsefulBufC UsefulOutBuf_SubString(UsefulOutBuf *pUOutBuf,
-                                  const size_t  uStart,
-                                  const size_t  uLen);
+UsefulBufC UsefulOutBuf_OutSubString(UsefulOutBuf *pUOutBuf,
+                                     const size_t  uStart,
+                                     const size_t  uLen);
 
 
 /**
@@ -1483,26 +1483,28 @@ static UsefulBuf UsefulOutBuf_RetrieveOutputStorage(UsefulOutBuf *pUOutBuf);
  * @return  0 for equality, positive if uStart1 is lexographically larger,
  *          negative if uStart2 is lexographically larger.
  *
- * This looks into bytes that have been output at the offsets @c start1
- * and @c start2. It compares bytes at those two starting points until
- * they are not equal or @c uLen1 or @c uLen2 is reached. If the
- * length of the string given is off the end of the output data, the
- * string will be effectively truncated to the data in the output
- * buffer for the comparison.
+ * This looks into bytes that have been output at the offsets
+ * @c start1 and @c start2. It compares bytes at those two starting
+ * points until they are not equal or @c uLen1 or @c uLen2 is
+ * reached. If the length of the string given is off the end of the
+ * output data, the string will be effectively (not actually)
+ * truncated to the data in the output buffer for the comparison.
  *
- * This returns positive when @c uStart1 lexographically sorts ahead
- * of @c uStart2 and vice versa.  Zero is returned if the strings
- * compare equally.
+ * This function returns a positive value if the first string
+ * lexicographically precedes the second and a negative value if the
+ * second precedes the first. If the strings are equal, it returns
+ * zero.
  *
- * If lengths are unequal and the first bytes are an exact subset of
- * the second string, then a positve value will be returned and vice
- * versa.
+ * If one string is a substring of the other, the shorter string is
+ * considered smaller. For example, if the first string is "ab" and
+ * the second is "abc", a positive value is returned. The empty string
+ * is always the smallest and sorts ahead of all others.
  *
- * If either start is past the end of data in the output buffer, 0
- * will be returned. It is the caller's responsibility to make sure
- * the offsets are not off the end so that a comparison is actually
- * being made. No data will ever be read off the end of the buffer so
- * this safe no matter what offsets are passed.
+ * If either starting offset is beyond the end of the output buffer,
+ * the function returns zero.  It is the caller’s responsibility to
+ * ensure that offsets are within bounds so that a valid comparison is
+ * performed. No data will ever be read beyond the buffer’s end,
+ * making the function safe regardless of the provided offsets.
  *
  * This is a relatively odd function in that it works on data in the
  * output buffer. It is employed by QCBOR to sort CBOR-encoded maps
@@ -2477,6 +2479,8 @@ static inline size_t UsefulInputBuf_BytesUnconsumed(UsefulInputBuf *pMe)
     * or was never initialized.
     */
    if(pMe->magic != UIB_MAGIC) {
+      /* Strangely gcov thinks the line is not covered by tests even
+       * though it clearly is (tested with break point and printf) */
       return 0;
    }
 
@@ -2710,6 +2714,12 @@ static inline UsefulBufC UsefulInputBuf_RetrieveUndecodedInput(UsefulInputBuf *p
    return pMe->UB;
 }
 
+
+/* For backwards compatibility */
+static inline UsefulBufC UsefulOutBuf_SubString(UsefulOutBuf *pMe, const size_t uStart, const size_t uLen)
+{
+   return UsefulOutBuf_OutSubString(pMe, uStart, uLen);
+}
 
 #ifdef __cplusplus
 }

--- a/inc/qcbor/qcbor_common.h
+++ b/inc/qcbor/qcbor_common.h
@@ -576,6 +576,12 @@ typedef enum {
     * See @ref QCBOR_DECODE_ALLOW_UNPROCESSED_TAG_NUMBERS. */
    QCBOR_ERR_UNPROCESSED_TAG_NUMBER = 90,
 
+   /** File a an issue in github if this happens!  For map sorting, QCBOR decodes the
+    * CBOR that it just encoded. This error is returned if QCBOR can't decode what
+    * it just encoded. */
+   QCBOR_ERR_SORT_FAIL = 91,
+
+
    /** A range of error codes that can be made use of by the
     * caller. QCBOR internally does nothing with these except notice
     * that they are not QCBOR_SUCCESS. See QCBORDecode_SetError(). */

--- a/inc/qcbor/qcbor_common.h
+++ b/inc/qcbor/qcbor_common.h
@@ -576,12 +576,6 @@ typedef enum {
     * See @ref QCBOR_DECODE_ALLOW_UNPROCESSED_TAG_NUMBERS. */
    QCBOR_ERR_UNPROCESSED_TAG_NUMBER = 90,
 
-   /** File a an issue in github if this happens!  For map sorting, QCBOR decodes the
-    * CBOR that it just encoded. This error is returned if QCBOR can't decode what
-    * it just encoded. */
-   QCBOR_ERR_SORT_FAIL = 91,
-
-
    /** A range of error codes that can be made use of by the
     * caller. QCBOR internally does nothing with these except notice
     * that they are not QCBOR_SUCCESS. See QCBORDecode_SetError(). */

--- a/inc/qcbor/qcbor_main_encode.h
+++ b/inc/qcbor/qcbor_main_encode.h
@@ -215,7 +215,7 @@ enum QCBOREncodeConfig {
     * set when trying to encode non-preferred big numbers with
     * QCBOREncode_AddTBigNumberNoPreferred() or
     * QCBOREncode_AddTBigNumberRaw(). */
-   QCBOR_ENCODE_CONFIG_ONLY_PREFERRED_BIG_NUMBERS = 0x40, // TODO: test this one
+   QCBOR_ENCODE_CONFIG_ONLY_PREFERRED_BIG_NUMBERS = 0x40,
 
 
    /**
@@ -1042,8 +1042,8 @@ QCBOREncode_CancelBstrWrap(QCBOREncodeContext *pCtx);
  * raw CBOR added here to have indefinite lengths.
  *
  * The raw CBOR added here is not checked in anyway. If it is not
- * conforming or has open arrays or such, the final encoded CBOR
- * will probably be wrong or not what was intended.
+ * well-formed or has open arrays or such, the final encoded CBOR
+ * will not be well-formed.
  *
  * If the encoded CBOR being added here contains multiple items, they
  * must be enclosed in a map or array. At the top level the raw

--- a/src/UsefulBuf.c
+++ b/src/UsefulBuf.c
@@ -1,6 +1,6 @@
 /*==============================================================================
  * Copyright (c) 2016-2018, The Linux Foundation.
- * Copyright (c) 2018-2024, Laurence Lundblade.
+ * Copyright (c) 2018-2025, Laurence Lundblade.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -44,6 +44,9 @@
 
  when        who          what, where, why
  --------    ----         ---------------------------------------------------
+ 02/21/2025  llundblade   Improve magic number to detect lack of initialization.
+ 02/21/2025  llundblade   Bug fixes to UsefulOutBuf_Compare().
+ 02/21/2025  llundblade   Rename to UsefulOutBuf_OutSubString().
  08/08/2024  llundblade   Add UsefulOutBuf_SubString().
  21/05/2024  llundblade   Comment formatting and some code tidiness.
  1/7/2024    llundblade   Add UsefulInputBuf_Compare().

--- a/src/qcbor_main_encode.c
+++ b/src/qcbor_main_encode.c
@@ -1331,5 +1331,5 @@ QCBOREncode_SubString(QCBOREncodeContext *pMe, const size_t uStart)
 
    const size_t uEnd = QCBOREncode_Tell(pMe);
 
-   return UsefulOutBuf_SubString(&(pMe->OutBuf), uStart, uEnd - uStart);
+   return UsefulOutBuf_OutSubString(&(pMe->OutBuf), uStart, uEnd - uStart);
 }

--- a/src/qcbor_main_encode.c
+++ b/src/qcbor_main_encode.c
@@ -937,12 +937,8 @@ QCBOREncode_Private_ConsumeNext(UsefulInputBuf *pInBuf)
       case CBOR_MAJOR_TYPE_NEGATIVE_INT: /* Major type 1 */
          break;
 
-      case CBOR_MAJOR_TYPE_SIMPLE:
-         return uArgument == CBOR_SIMPLE_BREAK ? QCBOR_ERR_HIT_END : QCBOR_SUCCESS;
-         break;
-
-      case CBOR_MAJOR_TYPE_BYTE_STRING:
-      case CBOR_MAJOR_TYPE_TEXT_STRING:
+      case CBOR_MAJOR_TYPE_BYTE_STRING: /* Major type 2 */
+      case CBOR_MAJOR_TYPE_TEXT_STRING: /* Major type 3 */
          if(nAdditional == LEN_IS_INDEFINITE) {
             /* Chunks of indefinite length string */
             do {
@@ -958,14 +954,13 @@ QCBOREncode_Private_ConsumeNext(UsefulInputBuf *pInBuf)
          }
          break;
 
-      case CBOR_MAJOR_TYPE_TAG:
-         uCBORError = QCBOREncode_Private_ConsumeNext(pInBuf);
-         break;
-
-      case CBOR_MAJOR_TYPE_MAP:
+      case CBOR_MAJOR_TYPE_MAP: /* Major type 5 */
          uMul = 2;
          /* Fallthrough */
-      case CBOR_MAJOR_TYPE_ARRAY:
+      case CBOR_MAJOR_TYPE_ARRAY: /* Major type 4 */
+         /* Cast is safe because this is decoding CBOR that was created
+          * by QCBOR and because QCBOREncode_Private_ConsumeNext() can
+          * never read off the end. */
          uItemCountTotal = (uint16_t)uArgument * uMul;
          if(nAdditional == LEN_IS_INDEFINITE) {
             uItemCountTotal = UINT16_MAX;
@@ -979,6 +974,14 @@ QCBOREncode_Private_ConsumeNext(UsefulInputBuf *pInBuf)
          if(nAdditional == LEN_IS_INDEFINITE && uCBORError == QCBOR_ERR_HIT_END) {
             uCBORError = QCBOR_SUCCESS;
          }
+         break;
+
+      case CBOR_MAJOR_TYPE_TAG: /* Major type 6 */
+         uCBORError = QCBOREncode_Private_ConsumeNext(pInBuf);
+         break;
+
+      case CBOR_MAJOR_TYPE_SIMPLE: /* Major type 7 */
+         return uArgument == CBOR_SIMPLE_BREAK ? QCBOR_ERR_HIT_END : QCBOR_SUCCESS;
          break;
    }
 

--- a/src/qcbor_main_encode.c
+++ b/src/qcbor_main_encode.c
@@ -839,10 +839,10 @@ QCBOREncode_Private_CloseMapUnsorted(QCBOREncodeContext *pMe)
  * change.
  */
 static QCBORError
-QCBOREncodePriv_DecodeHead(UsefulInputBuf *pUInBuf,
-                           int            *pnMajorType,
-                           uint64_t       *puArgument,
-                           int            *pnAdditionalInfo)
+QCBOREncode_Private_DecodeHead(UsefulInputBuf *pUInBuf,
+                               int            *pnMajorType,
+                               uint64_t       *puArgument,
+                               int            *pnAdditionalInfo)
 {
    QCBORError uReturn;
 
@@ -899,25 +899,38 @@ Done:
  *
  * @param[in] pInBuf  UsefulInputBuf from which to consume item.
  *
- * Recursive, but stack usage is light and encoding depth limit
+ * @retval QCBOR_SUCCESS  The next item has been consumed successfully.
+ *
+ * @retval QCBOR_ERR_HIT_END The next item is a break or has hit the end.
+ *
+ * @retval a QCOR error code indicating some decode failure
+ *
+ * Recursive, but stack usage is light and encoding depth limited.
  */
 static QCBORError
-QCBOR_Private_ConsumeNext(UsefulInputBuf *pInBuf)
+QCBOREncode_Private_ConsumeNext(UsefulInputBuf *pInBuf)
 {
-   int      nMajor;
-   uint64_t uArgument;
-   int      nAdditional;
-   uint16_t uItemCount;
-   uint16_t uMul;
-   uint16_t i;
+   int        nMajor;
+   uint64_t   uArgument;
+   int        nAdditional;
+   uint16_t   uItemCountTotal;
+   uint16_t   uMul;
+   uint16_t   uItemCounter;
    QCBORError uCBORError;
 
-   uCBORError = QCBOREncodePriv_DecodeHead(pInBuf, &nMajor, &uArgument, &nAdditional);
+   uCBORError = QCBOREncode_Private_DecodeHead(pInBuf, &nMajor, &uArgument, &nAdditional);
    if(uCBORError != QCBOR_SUCCESS) {
-      return uCBORError;
+      goto Done;
    }
 
    uMul = 1;
+
+   /* This intentionally doesn't check for a some not-well-formed
+    * conditions such as the wrong type in an indefinite length
+    * string chunk and the disallowed forms of the simple type.
+    * These conditions should never occur because this only decodes
+    * what was encoded by QCBOR. This saves object code.
+    */
 
    switch(nMajor) {
       case CBOR_MAJOR_TYPE_POSITIVE_INT: /* Major type 0 */
@@ -925,40 +938,52 @@ QCBOR_Private_ConsumeNext(UsefulInputBuf *pInBuf)
          break;
 
       case CBOR_MAJOR_TYPE_SIMPLE:
-         return uArgument == CBOR_SIMPLE_BREAK ? 1 : 0;
+         return uArgument == CBOR_SIMPLE_BREAK ? QCBOR_ERR_HIT_END : QCBOR_SUCCESS;
          break;
 
       case CBOR_MAJOR_TYPE_BYTE_STRING:
       case CBOR_MAJOR_TYPE_TEXT_STRING:
          if(nAdditional == LEN_IS_INDEFINITE) {
-            /* Segments of indefinite length */
-            while(QCBOR_Private_ConsumeNext(pInBuf) == 0);
+            /* Chunks of indefinite length string */
+            do {
+               uCBORError = QCBOREncode_Private_ConsumeNext(pInBuf);
+            } while(uCBORError == QCBOR_SUCCESS);
+            if(uCBORError != QCBOR_ERR_HIT_END) {
+               return uCBORError;
+            }
+            uCBORError = QCBOR_SUCCESS;
+         } else {
+            /* The bytes of a definite length string */
+            (void)UsefulInputBuf_GetBytes(pInBuf, uArgument);
          }
-         (void)UsefulInputBuf_GetBytes(pInBuf, uArgument);
          break;
 
       case CBOR_MAJOR_TYPE_TAG:
-         QCBOR_Private_ConsumeNext(pInBuf);
+         uCBORError = QCBOREncode_Private_ConsumeNext(pInBuf);
          break;
 
       case CBOR_MAJOR_TYPE_MAP:
          uMul = 2;
          /* Fallthrough */
       case CBOR_MAJOR_TYPE_ARRAY:
-         uItemCount = (uint16_t)uArgument * uMul;
+         uItemCountTotal = (uint16_t)uArgument * uMul;
          if(nAdditional == LEN_IS_INDEFINITE) {
-            uItemCount = UINT16_MAX;
+            uItemCountTotal = UINT16_MAX;
          }
-         for(i = uItemCount; i > 0; i--) {
-            if(QCBOR_Private_ConsumeNext(pInBuf)) {
-               /* End of indefinite length */
+         for(uItemCounter = uItemCountTotal; uItemCounter > 0; uItemCounter--) {
+            uCBORError = QCBOREncode_Private_ConsumeNext(pInBuf);
+            if(uCBORError != QCBOR_SUCCESS) {
                break;
             }
+         }
+         if(nAdditional == LEN_IS_INDEFINITE && uCBORError == QCBOR_ERR_HIT_END) {
+            uCBORError = QCBOR_SUCCESS;
          }
          break;
    }
 
-   return QCBOR_SUCCESS;
+Done:
+   return uCBORError;
 }
 
 
@@ -999,23 +1024,26 @@ QCBOREncode_Private_DecodeNextInMap(QCBOREncodeContext *pMe, uint32_t uStart)
    UsefulInputBuf_Init(&InBuf, EncodedMapBytes);
 
    /* This is always used on maps, so consume two, the label and the value */
-   uCBORError = QCBOR_Private_ConsumeNext(&InBuf);
-   if(uCBORError) {
+   uCBORError = QCBOREncode_Private_ConsumeNext(&InBuf);
+   if(uCBORError != QCBOR_SUCCESS) {
+      pMe->uError = (uint8_t)uCBORError;
+      Result.uLabelLen = 0;
       return Result;
    }
 
    /* Cast is safe because this is QCBOR which limits sizes to UINT32_MAX */
    Result.uLabelLen = (uint32_t)UsefulInputBuf_Tell(&InBuf);
 
-   uCBORError = QCBOR_Private_ConsumeNext(&InBuf);
-   if(uCBORError) {
+   uCBORError = QCBOREncode_Private_ConsumeNext(&InBuf);
+   if(uCBORError != QCBOR_SUCCESS) {
+      pMe->uError = (uint8_t)uCBORError;
       Result.uLabelLen = 0;
       return Result;
    }
 
+   /* Cast is safe because this is QCBOR which limits sizes to UINT32_MAX */
    Result.uItemLen = (uint32_t)UsefulInputBuf_Tell(&InBuf);
 
-   /* Cast is safe because this is QCBOR which limits sizes to UINT32_MAX */
    return Result;
 }
 
@@ -1093,7 +1121,7 @@ QCBOREncode_Private_SortMap(QCBOREncodeContext *pMe, uint32_t uStart)
          }
          uStart2 = uStart2 + Lens2.uItemLen;
       }
-   } while(bSwapped);
+   } while(bSwapped && pMe->uError == QCBOR_SUCCESS);
 }
 
 

--- a/src/qcbor_number_encode.c
+++ b/src/qcbor_number_encode.c
@@ -1,6 +1,6 @@
 /* ===========================================================================
  * Copyright (c) 2016-2018, The Linux Foundation.
- * Copyright (c) 2018-2024, Laurence Lundblade.
+ * Copyright (c) 2018-2025, Laurence Lundblade.
  * Copyright (c) 2021, Arm Limited.
  * All rights reserved.
  *
@@ -226,7 +226,7 @@ QCBOREncode_Private_BigNumberToUInt(const UsefulBufC BigNumber)
 
 
 /**
- * @brief Is there a carry when you subtract 1 from the BigNumber.
+ * @brief Is there a carry when you subtract 1 from the BigNumber?
  *
  * @param[in]  BigNumber  Big number to check for carry.
  *
@@ -331,9 +331,9 @@ QCBOREncode_Private_AddTNegativeBigNumber(QCBOREncodeContext *pMe,
  * @return Big number with no leading zeros.
  *
  * If the big number is all zeros, this returns a big number that is
- * one zero rather than the empty string.
+ * a single zero rather than the empty string.
  *
- * RFC 8949 3.4.3 does not explicitly decoders MUST handle the empty
+ * RFC 8949 3.4.3 does not explicitly say decoders MUST handle the empty
  * string, but does say decoders MUST handle leading zeros. So
  * Postel's Law is applied here and 0 is not encoded as an empty
  * string.

--- a/test/float_tests.c
+++ b/test/float_tests.c
@@ -323,12 +323,17 @@ static const struct FloatTestCase FloatTestCases[] =  {
     {"\xFB\x7F\xEF\xFF\xFF\xFF\xFF\xFF\xFF", 9}, {"\xFB\x7F\xEF\xFF\xFF\xFF\xFF\xFF\xFF", 9},
     {"\xFB\x7F\xEF\xFF\xFF\xFF\xFF\xFF\xFF", 9}, {"\xFB\x7F\xEF\xFF\xFF\xFF\xFF\xFF\xFF", 9}},
 
+   /* -18446744073709551616.0 -- largest that encodes into negative uint64 (65-bit neg) */
+   {-18446744073709551616.0,                     -18446744073709551616.0f,
+    {"\xFA\xDF\x80\x00\x00",                 5}, {"\xFB\xC3\xF0\x00\x00\x00\x00\x00\x00", 9},
+    {"\xFA\xDF\x80\x00\x00",                 5}, {"\x3B\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF", 9}},
+
    /* List terminator */
    {0.0, 0.0f, {NULL, 0}, {NULL, 0}, {NULL, 0}, {NULL, 0} }
 };
 
 
-/* Can't use types double and float here because there's no way in C to
+/* Can't use the types double and float here because there's no way in C to
  * construct arbitrary payloads for those types.
  */
 struct NaNTestCase {
@@ -416,7 +421,7 @@ FloatValuesTests(void)
    for(uTestIndex = 0; FloatTestCases[uTestIndex].Preferred.len != 0; uTestIndex++) {
       pTestCase = &FloatTestCases[uTestIndex];
 
-      if(uTestIndex == 2) {
+      if(uTestIndex == 48) {
          uDecoded = 1;
       }
 

--- a/test/qcbor_encode_tests.c
+++ b/test/qcbor_encode_tests.c
@@ -1080,18 +1080,24 @@ int32_t BigNumEncodeTests(void)
       }
    }
 
+#ifndef QCBOR_DISABLE_ENCODE_USAGE_GUARDS
+   QCBORError uExpectedErr = QCBOR_ERR_NOT_PREFERRED;
+#else
+   QCBORError uExpectedErr = QCBOR_SUCCESS;
+#endif /* !QCBOR_DISABLE_ENCODE_USAGE_GUARDS */
+
    /* Test failure for attempting non-prefered serialiation */
    QCBOREncode_Init(&Enc, UsefulBuf_FROM_BYTE_ARRAY(spBigBuf));
    QCBOREncode_Config(&Enc, QCBOR_ENCODE_CONFIG_ONLY_PREFERRED_BIG_NUMBERS);
    QCBOREncode_AddTBigNumberRaw(&Enc, QCBOR_ENCODE_AS_TAG, false, UsefulBuf_FROM_SZ_LITERAL("\x00"));
-   if(QCBOREncode_GetErrorState(&Enc) != QCBOR_ERR_NOT_PREFERRED) {
+   if(QCBOREncode_GetErrorState(&Enc) != uExpectedErr) {
       return -1;
    }
 
    QCBOREncode_Init(&Enc, UsefulBuf_FROM_BYTE_ARRAY(spBigBuf));
    QCBOREncode_Config(&Enc, QCBOR_ENCODE_CONFIG_ONLY_PREFERRED_BIG_NUMBERS);
    QCBOREncode_AddTBigNumberNoPreferred(&Enc, QCBOR_ENCODE_AS_TAG, false, UsefulBuf_FROM_SZ_LITERAL("\x00"));
-   if(QCBOREncode_GetErrorState(&Enc) != QCBOR_ERR_NOT_PREFERRED) {
+   if(QCBOREncode_GetErrorState(&Enc) != uExpectedErr) {
       return -2;
    }
 
@@ -3547,6 +3553,7 @@ OpenCloseBytesTest(void)
 }
 
 
+#ifndef QCBOR_DISABLE_INDEFINITE_LENGTH_ARRAYS
 
 struct SortTests {
    const char *szDescription;
@@ -3613,7 +3620,7 @@ static const struct SortTests sSortTests[] =
       QCBOR_SUCCESS
    }
 };
-
+#endif /* ! QCBOR_DISABLE_INDEFINITE_LENGTH_ARRAYS */
 
 int32_t
 SortMapTest(void)
@@ -3623,6 +3630,8 @@ SortMapTest(void)
    UsefulBufC                 EncodedAndSorted;
    QCBORError                 uErr;
    struct UBCompareDiagnostic CompareDiagnostics;
+
+#ifndef QCBOR_DISABLE_INDEFINITE_LENGTH_ARRAYS
 
    for(int nIndex = 0; ; nIndex++) {
       const struct SortTests *pTest = &sSortTests[nIndex];
@@ -3657,6 +3666,7 @@ SortMapTest(void)
          }
       }
    }
+#endif /* ! QCBOR_DISABLE_INDEFINITE_LENGTH_ARRAYS */
    // TODO: Move most of the tests below into sSortTests
 
 
@@ -4203,11 +4213,9 @@ int32_t DCBORTest(void)
    QCBOREncode_Init(&EC, UsefulBuf_FROM_BYTE_ARRAY(spBigBuf));
    QCBOREncode_Config(&EC, QCBOR_ENCODE_CONFIG_DCBOR);
    QCBOREncode_AddUndef(&EC);
-   QCBOREncode_CloseMap(&EC);
    if(QCBOREncode_GetErrorState(&EC) != uExpectedErr) {
       return 102;
    }
-
 
    /* Improvement: when indefinite length string encoding is supported
     * test it here too. */

--- a/test/qcbor_encode_tests.c
+++ b/test/qcbor_encode_tests.c
@@ -3555,14 +3555,14 @@ OpenCloseBytesTest(void)
 
 #ifndef QCBOR_DISABLE_INDEFINITE_LENGTH_ARRAYS
 
-struct SortTests {
+struct SortTest {
    const char *szDescription;
-   UsefulBufC   ToBeSorted;
-   UsefulBufC   Sorted;
-   QCBORError   uError;
+   UsefulBufC  ToBeSorted;
+   UsefulBufC  Sorted;
+   QCBORError  uError;
 };
 
-static const struct SortTests sSortTests[] =
+static const struct SortTest sSortTests[] =
 {
    {
       "Simple Sort Test",
@@ -3614,6 +3614,17 @@ static const struct SortTests sSortTests[] =
    },
 
    {
+      "All sorts of labels",
+      {"\x81\x00\x03\xFB\x40\x09\x1E\xB8\x51\xEB\x85\x1F\x01\xf4\x04\xa2"
+       "\x05\x05\x06\x06\x02\xc1\x38\xff\x05\x81\x01\x06\x81\x20\x07\x19"
+       "\x00\x01\x08", 35},
+      {"\xBF\x19\x00\x01\x08\x81\x00\x03\x81\x01\x06\x81\x20\x07\xA2\x05"
+       "\x05\x06\x06\x02\xC1\x38\xFF\x05\xF4\x04\xFB\x40\x09\x1E\xB8\x51"
+       "\xEB\x85\x1F\x01\xFF", 37},
+      QCBOR_SUCCESS
+   },
+
+   {
       NULL,
       NULLUsefulBufC,
       NULLUsefulBufC,
@@ -3634,13 +3645,13 @@ SortMapTest(void)
 #ifndef QCBOR_DISABLE_INDEFINITE_LENGTH_ARRAYS
 
    for(int nIndex = 0; ; nIndex++) {
-      const struct SortTests *pTest = &sSortTests[nIndex];
+      const struct SortTest *pTest = &sSortTests[nIndex];
 
       if(pTest->szDescription == NULL) {
          break;
       }
 
-      if(nIndex == 6) {
+      if(nIndex == 7) {
          uErr = 0; /* For break point */
       }
 


### PR DESCRIPTION
UsefulBuf test coverage back up to 100% (filled out coverage for new v2 features)

UsefulOutBuf_Compare() bugs for unequal length comparisons and comparisons off the end of the buffer

Improve UsefulOutBuf magic number check

UsefulOutBuf_OutSubString renamed to UsefulOutBuf_SubString for consistency. Old name still supported.
