### PR TITLE
C23 compatibility: don't use false as NULL

### DIFF
--- a/src/qcbor_decode.c
+++ b/src/qcbor_decode.c
@@ -4238,7 +4238,7 @@ QCBORDecode_Private_ExitBoundedLevel(QCBORDecodeContext *pMe,
     * level is reached.  It may do nothing, or ascend all the way to
     * the top level.
     */
-   uErr = QCBORDecode_Private_NestLevelAscender(pMe, NULL, false);
+   uErr = QCBORDecode_Private_NestLevelAscender(pMe, NULL, NULL);
    if(uErr != QCBOR_SUCCESS) {
       goto Done;
    }


### PR DESCRIPTION
C23 defines false as a keyword, which prevents it from being used as a NULL pointer. Needed a fix in one spot.