### PR TITLE
rename QCBORDecode_GetErrorAndReset to QCBORDecode_GetAndResetError in documentation

### DIFF
--- a/inc/qcbor/qcbor_decode.h
+++ b/inc/qcbor/qcbor_decode.h
@@ -122,13 +122,13 @@ extern "C" {
  * successfully decoded before examining their value or type.
  *
  * The internal decode error state can be reset by reinitializing the
- * decoder or calling QCBORDecode_GetErrorAndReset(). Code calling
+ * decoder or calling QCBORDecode_GetAndResetError(). Code calling
  * QCBOR may take advantage of the internal error state to halt
  * futher decoding and propagate errors it detects using
  * QCBORDecode_SetError().
  *
  * It is only useful to reset the error state by calling
- * QCBORDecode_GetErrorAndReset() on recoverable errors. Examples of
+ * QCBORDecode_GetAndResetError() on recoverable errors. Examples of
  * recoverable errors are a map entry not being found or integer
  * overflow or underflow during conversion. Examples of unrecoverable
  * errors are hitting the end of the input and array or map nesting


### PR DESCRIPTION
fixes documentation defined at https://www.securitytheory.com/qcbor-docs/qcbor__main__decode_8h