### PR TITLE
Fix bug due to uninitialized variable in qcbor_decode.c

### DIFF
--- a/src/qcbor_decode.c
+++ b/src/qcbor_decode.c
@@ -3139,6 +3139,8 @@ QCBORDecode_SetMemPool(QCBORDecodeContext *pMe,
  * @param[in]  pMe              The decoder context.
  * @param[in]  pItemToConsume   The array/map whose contents are to be
  *                              consumed.
+ * @param[out] pbBreak          Set to true if extra break was consumed.
+ *                              Can be NULL.
  * @param[out] puNextNestLevel  The next nesting level after the item was
  *                              fully consumed.
  *
@@ -3178,8 +3180,11 @@ QCBORDecode_Private_ConsumeItem(QCBORDecodeContext *pMe,
 
    } else {
       /* pItemToConsume is not a map or array. Just pass the nesting
-       * level through. */
+       * level through.  Ensure pbBreak is false. */
       *puNextNestLevel = pItemToConsume->uNextNestLevel;
+      if(pbBreak) {
+         *pbBreak = false;
+      }
 
       uReturn = QCBOR_SUCCESS;
    }


### PR DESCRIPTION
In QCBORDecode_Private_ConsumeItem pbBreak is not set when the array is empty.  As a result if the calling function passes an uninitialized value and the array is empty, the function may assume that the last character has to be removed.

The issue was noticed by the GetMapAndArrayTest failing with code 59.

Changelog:
- In the branch of empty array, explicitly set pbBreak to false
- Add pbBreak param to the function comment

Tests:
- All tests pass in debug and release mode