### PR TITLE
Fix handling of NaN & Infinity conversion to int using newlib.nano

### DIFF
--- a/pkg/qcbor.spec
+++ b/pkg/qcbor.spec
@@ -57,5 +57,6 @@ Development files needed to build and link to the QCBOR library.
 - Bug fix for QCBORDecode_GetMap() and QCBORDecode_GetArray()
 - Fix warning for compilers compliant with C23 standard
 - Minor documentation fix
+- Fix for embedded platforms with partial implementations of llround()
 * Jan 8 2024 Laurence Lundblade <lgl@island-resort.com> - 1.5.1
 - Initial library RPM packaging.

--- a/src/qcbor_decode.c
+++ b/src/qcbor_decode.c
@@ -5466,8 +5466,8 @@ QCBOR_Private_ConvertInt64(const QCBORItem *pItem,
                            int64_t         *pnValue)
 {
    switch(pItem->uDataType) {
-      case QCBOR_TYPE_FLOAT:
 #ifndef QCBOR_DISABLE_FLOAT_HW_USE
+      case QCBOR_TYPE_FLOAT:
          if(!(uConvertTypes & QCBOR_CONVERT_TYPE_FLOAT)) {
             return  QCBOR_ERR_UNEXPECTED_TYPE;
          }
@@ -5524,6 +5524,8 @@ QCBOR_Private_ConvertInt64(const QCBORItem *pItem,
          break;
 
 #else /* ! QCBOR_DISABLE_FLOAT_HW_USE */
+      case QCBOR_TYPE_FLOAT:
+      case QCBOR_TYPE_DOUBLE:
          return QCBOR_ERR_HW_FLOAT_DISABLED;
 #endif /* ! QCBOR_DISABLE_FLOAT_HW_USE */
          break;

--- a/test/qcbor_decode_tests.c
+++ b/test/qcbor_decode_tests.c
@@ -7810,6 +7810,17 @@ static const struct NumberConversion NumberConversions[] = {
       INFINITY,
       FLOAT_ERR_CODE_NO_FLOAT_HW(QCBOR_SUCCESS)
    },
+
+   {
+      "-inifinity single precision",
+      {(uint8_t[]){0xfa, 0xff, 0x80, 0x00, 0x00}, 5},
+      0,
+      FLOAT_ERR_CODE_NO_FLOAT_HW(QCBOR_ERR_FLOAT_EXCEPTION),
+      0,
+      FLOAT_ERR_CODE_NO_FLOAT_HW(QCBOR_ERR_NUMBER_SIGN_CONVERSION),
+      -INFINITY,
+      FLOAT_ERR_CODE_NO_FLOAT_HW(QCBOR_SUCCESS)
+   },
 };
 
 
@@ -7847,7 +7858,13 @@ int32_t IntegerConvertTest(void)
          return (int32_t)(3333+nIndex);
       }
 
+
       int64_t nInt;
+
+      if(nIndex == 27) {
+         nInt = 9;
+      }
+
       QCBORDecode_GetInt64ConvertAll(&DCtx, 0xffff, &nInt);
       if(QCBORDecode_GetError(&DCtx) != pF->uErrorInt64) {
          return (int32_t)(2000+nIndex);


### PR DESCRIPTION
llround() doesn't through exceptions for some embedded implementations.

This probably fixes #25 