### PR TITLE
MapSearch: Zero-Initialize pInfo

### DIFF
--- a/src/qcbor_decode.c
+++ b/src/qcbor_decode.c
@@ -3344,6 +3344,11 @@ QCBORDecode_Private_MapSearch(QCBORDecodeContext *pMe,
    QCBORError uReturn;
    uint64_t   uFoundItemBitMap = 0;
 
+   if (pInfo) {
+      pInfo->uItemCount = 0;
+      pInfo->uStartOffset = 0;
+   }
+
    if(pMe->uLastError != QCBOR_SUCCESS) {
       uReturn = pMe->uLastError;
       goto Done2;


### PR DESCRIPTION
It seems like `QCBORDecode_Private_MapSearch` assumes the return param `pInfo` to be zero initialized. Some code paths through this function set `pInfo->uItemCount`, but do not touch `pInfo->uStartOffset`. 

We had a case with `QCBORDecode_GetArrayFromMapSZ`, input is a CBOR map, with a single key, that has an array.
In this case, it would fail whenever the pInfo would not start as 0-initialized