### PR TITLE
Fix use of unitialized value bug reported by MemorySanitizer

### DIFF
--- a/src/qcbor_decode.c
+++ b/src/qcbor_decode.c
@@ -3171,11 +3171,8 @@ QCBORDecode_Private_ConsumeItem(QCBORDecodeContext *pMe,
 
    } else {
       /* pItemToConsume is not a map or array. Just pass the nesting
-       * level through.  Ensure pbBreak is false. */
+       * level through. */
       *puNextNestLevel = pItemToConsume->uNextNestLevel;
-      if(pbBreak) {
-         *pbBreak = false;
-      }
 
       uReturn = QCBOR_SUCCESS;
    }
@@ -3626,7 +3623,7 @@ QCBORDecode_Private_GetArrayOrMap(QCBORDecodeContext *pMe,
    size_t     uTempSaveCursor;
    bool       bInMap;
    QCBORItem  LabelItem;
-   bool       EndedByBreak;
+   bool       EndedByBreak = false;
 
    uStartingCursor = UsefulInputBuf_Tell(&(pMe->InBuf));
    bInMap = DecodeNesting_IsCurrentTypeMap(&(pMe->nesting));


### PR DESCRIPTION
In a toolchain with msan (aka MemorySanitizer) enabled, it catches 

```
==3130765==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0xxxx in UsefulBuf_Compare src/UsefulBuf.c:100:15
    #1  0xxxx in GetMapAndArrayTest test/qcbor_decode_tests.c:10084:7
    #2  0xxxx in RunTestsQCBOR third_party/qcbor/test/run_tests.c:296:31
    ......
```

This is because the expression involving `EndedByBreak` is always wrapped in

```
if (EndedByBreakPtr) {
  *EndedByBreakPtr = false (or true)
}
```

Some compiler might assume that if the memory is not yet allocating resulting to the expression being valuated to `false`, the value might never get initialized.

This PR aims to fix that bug.